### PR TITLE
Feature#140

### DIFF
--- a/src/components/toast/ToasterWithMax.tsx
+++ b/src/components/toast/ToasterWithMax.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import toast, { Toaster, useToasterStore } from 'react-hot-toast';
+
+export default function ToasterWithMax() {
+  const { toasts } = useToasterStore();
+  const [toastLimit, setToastLimit] = useState<number>(2);
+
+  useEffect(() => {
+    toasts
+      .filter((t) => t.visible)
+      .filter((_, i) => i >= toastLimit)
+      .forEach((t) => toast.dismiss(t.id));
+  }, [toasts, toastLimit]);
+
+  return (
+    <>
+      <Toaster
+        containerStyle={{
+          position: 'fixed',
+          maxHeight: '0.5rem',
+        }}
+        toastOptions={{
+          style: {
+            fontWeight: 600,
+            padding: '0.5rem',
+          },
+        }}
+      />
+    </>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,19 +44,6 @@ export default function App({ Component, pageProps }: AppProps) {
       </CookiesProvider>
 
       <ToasterWithMax />
-      {/* <Toaster\
-        containerStyle={{
-          position: 'fixed',
-          // overflow: 'hidden',
-          maxHeight: '0.5rem',
-        }}
-        toastOptions={{
-          duration: 2000,
-          style: {
-            fontWeight: 600,
-            padding: '0.5rem'},
-        }}
-      /> */}
     </>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { CookiesProvider } from 'react-cookie';
 import { Toaster } from 'react-hot-toast';
 import Layout from '@/components/layout';
+import ToasterWithMax from '@/components/toast/ToasterWithMax';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -42,20 +43,20 @@ export default function App({ Component, pageProps }: AppProps) {
         </QueryClientProvider>
       </CookiesProvider>
 
-      <Toaster
+      <ToasterWithMax />
+      {/* <Toaster\
         containerStyle={{
           position: 'fixed',
-          overflow: 'hidden',
-          maxHeight: '5rem',
+          // overflow: 'hidden',
+          maxHeight: '0.5rem',
         }}
         toastOptions={{
+          duration: 2000,
           style: {
             fontWeight: 600,
-            padding: '0.75rem 1rem',
-            marginTop: '0.5rem',
-          },
+            padding: '0.5rem'},
         }}
-      />
+      /> */}
     </>
   );
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close #140 

## 🚀 작업 내용
**Toast가 여러개 떠야 하는데 하나만 띄던 오류 해결**
<img width="959" alt="스크린샷 2024-06-06 오후 9 16 16" src="https://github.com/COW-dev/ddingdong-fe/assets/108217858/ffe3560e-c46a-4fd6-8f25-b3ea0bde2393">

**문제 상황**
기존 custom이였던 `overflow: 'hidden'` 때문에 나머지 Toast도 가려져서 생긴 에러입니다!

**해결방법**
`overflow: 'hidden'`을 지우고 테스트를 해보니까 나머지 Toast들도 잘 떴습니다. 여기서 또 문제 상황이 생겼는데, 제출하기를 계속 누를 때마다 Toast가 계속 쌓이는 상황이 발생했습니다.
따라서 limit을 줘야겠다고 생각했습니다! 공식문서에 명시되어 있는 것 없고, 그나마 깃허브 이슈에 임의적으로 해결해놓으신 것 보고 구현해놨습니다~! 현재는 2개까지만 뜨도록 구현해놨습니당

https://github.com/timolins/react-hot-toast/issues/31

## 💬 리뷰 중점사항
와이파이 상황이 좋지 않은 곳 (예를 들면 명지대..)에서 테스트 해봐야 할 것 같습니다!