### PR TITLE
refresh_token, access_token 삭제

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -504,8 +504,6 @@ export async function getApplier(
 
 //error handling
 function expirationToken(error: AxiosError<ErrorType>) {
-  // const cookies = new Cookies(); //?
-  // cookies.getAll();  //?
   removeToken();
   window.location.href = '/login';
   toast.error(error.response?.data?.message ?? `로그인 시간이 만료되었어요.`);

--- a/src/pages/admin/login/index.tsx
+++ b/src/pages/admin/login/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/named */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { AxiosResponse } from 'axios';
@@ -16,8 +16,20 @@ export default function Index() {
   const [id, setId] = useState<string>('');
   const [pw, setPw] = useState<string>('');
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [cookie, setCookie, removeCookie] = useCookies(['token', 'role']);
+  const [cookie, setCookie, removeCookie] = useCookies([
+    'token',
+    'role',
+    'access_token',
+    'refresh_token',
+  ]);
   const { setAuth } = useAuthStore();
+
+  useEffect(() => {
+    if (cookie.refresh_token || cookie.access_token) {
+      removeCookie('refresh_token');
+      removeCookie('access_token');
+    }
+  }, [cookie, removeCookie]);
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();


### PR DESCRIPTION
## 🔥 연관 이슈

- close #170 

## 🚀 작업 내용

- admin 페이지 refresh_token, access_token있을 경우 삭제
- localhost에서는 테스트가 불가하여 테스트 못해봤습니다. 배포된 버셀에서 확인해야 될 것 같습니다.