### PR TITLE
동아리원 명단 조회 API 변경

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -257,7 +257,7 @@ export async function getClubMembers(
 
 export async function uploadMembers(formdata: FormData) {
   const token = formdata.get('token');
-  return await api.post('/club/my/club-members', formdata, {
+  return await api.post('/central/my/club-members', formdata, {
     headers: {
       Authorization: 'Bearer ' + token,
     },
@@ -265,7 +265,7 @@ export async function uploadMembers(formdata: FormData) {
 }
 
 export async function updateMembers({ member, id, token }: UpdateMember) {
-  return await api.patch(`/club/my/club-members/${id}`, member, {
+  return await api.patch(`/central/my/club-members/${id}`, member, {
     headers: {
       Authorization: 'Bearer ' + token,
     },

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -19,7 +19,7 @@ import {
   UpdateClub,
   UpdateMember,
   UpdateMyClub,
-  Member,
+  MemberInfo,
 } from '@/types/club';
 import {
   DeleteDocument,
@@ -247,8 +247,8 @@ export async function updateNotice({
 
 export async function getClubMembers(
   token: string,
-): Promise<AxiosResponse<Array<Member>>> {
-  return await api.get(`/central/my/club-members`, {
+): Promise<AxiosResponse<MemberInfo, unknown>> {
+  return await api.get('/central/my/club-members', {
     headers: {
       Authorization: 'Bearer ' + token,
     },
@@ -273,7 +273,7 @@ export async function updateMembers({ member, id, token }: UpdateMember) {
 }
 
 export async function getMemberFile(token: string) {
-  return await api.get('/club/my/club-members/excel', {
+  return await api.get('/central/my/club-members/excel', {
     headers: {
       Authorization: 'Bearer ' + token,
     },

--- a/src/components/common/ColorSelect.tsx
+++ b/src/components/common/ColorSelect.tsx
@@ -3,14 +3,11 @@ import Image from 'next/image';
 import ArrowDown from '@/assets/arrowDown.svg';
 import ArrowUp from '@/assets/arrowUp.svg';
 import { ItemsType } from '@/constants/color';
-import { NewBannerType } from '@/types/banner';
 import { NewClub } from '@/types/club';
 
 type SelectProps = {
   name: string;
-  setData:
-    | Dispatch<SetStateAction<NewBannerType>>
-    | Dispatch<SetStateAction<NewClub>>;
+  setData: Dispatch<SetStateAction<NewClub>>;
   list: ItemsType[];
 };
 

--- a/src/components/modal/report/Paticipants.tsx
+++ b/src/components/modal/report/Paticipants.tsx
@@ -46,7 +46,7 @@ export default function Participants({ data, setData, closeModal }: Props) {
           <ParticipantSelect
             name={participant.name}
             setData={setParticipants}
-            list={clubMemberData?.data ?? []}
+            list={clubMemberData?.data.clubMembers ?? []}
             id={index}
           />
         </div>

--- a/src/hooks/api/member/useClubMembers.ts
+++ b/src/hooks/api/member/useClubMembers.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { AxiosError, type AxiosResponse } from 'axios';
 import { getClubMembers } from '@/apis';
-import { Member } from '@/types/club';
+import { MemberInfo } from '@/types/club';
 
 export function useClubMembers(token: string) {
-  return useQuery<unknown, AxiosError, AxiosResponse<Member[]>>({
+  return useQuery<unknown, AxiosError, AxiosResponse<MemberInfo>>({
     queryKey: ['/central/my/club-members'],
     queryFn: () => getClubMembers(token),
   });

--- a/src/hooks/api/member/useMemberFile.ts
+++ b/src/hooks/api/member/useMemberFile.ts
@@ -4,7 +4,7 @@ import { getMemberFile } from '@/apis';
 
 export function useMemberFile(token: string) {
   return useQuery<unknown, AxiosError, AxiosResponse<Blob>>({
-    queryKey: ['/central/my/club-members'],
+    queryKey: ['/central/my/club-members/excel'],
     queryFn: () => getMemberFile(token),
   });
 }

--- a/src/hooks/api/member/useMemberFile.ts
+++ b/src/hooks/api/member/useMemberFile.ts
@@ -4,7 +4,7 @@ import { getMemberFile } from '@/apis';
 
 export function useMemberFile(token: string) {
   return useQuery<unknown, AxiosError, AxiosResponse<Blob>>({
-    queryKey: ['/club/my/club-members'],
+    queryKey: ['/central/my/club-members'],
     queryFn: () => getMemberFile(token),
   });
 }

--- a/src/pages/admin/member/index.tsx
+++ b/src/pages/admin/member/index.tsx
@@ -4,22 +4,19 @@ import { useCookies } from 'react-cookie';
 import ExcelDropdown from '@/components/common/ExelDropdown';
 import SearchBar from '@/components/home/SearchBar';
 import MemberInfo from '@/components/member/MemberInfo';
-
-import { useMyClub } from '@/hooks/api/club/useMyClub';
+import { useClubMembers } from '@/hooks/api/member/useClubMembers';
 import { Member } from '@/types/club';
 
 export default function Index() {
   const [keyword, setKeyword] = useState<string>('');
   const [{ token }] = useCookies(['token']);
-
-  const { data } = useMyClub(token);
-
+  const { data: data } = useClubMembers(token);
   const [members, setMembers] = useState<Member[]>([]);
   const [filteredMembers, setFilteredMembers] = useState<Member[]>([]);
 
   useEffect(() => {
-    setMembers(data?.clubMembers ?? []);
-    setFilteredMembers(data?.clubMembers ?? []);
+    setMembers(data?.data.clubMembers ?? []);
+    setFilteredMembers(data?.data.clubMembers ?? []);
   }, [data]);
 
   useEffect(() => {
@@ -46,7 +43,7 @@ export default function Index() {
       <div className="mb-7 flex justify-between">
         <div className="flex items-center text-xl font-bold">
           <span className="hidden md:inline-block">
-            {data?.name?.toUpperCase()}의&nbsp;
+            {data?.data.clubName?.toUpperCase()}의&nbsp;
           </span>
           동아리원은 총
           <span className="text-blue-500"> {members.length}명</span>

--- a/src/types/club.ts
+++ b/src/types/club.ts
@@ -53,6 +53,11 @@ export type ClubDetail = {
   formUrl: string;
 };
 
+export type MemberInfo = {
+  clubName: string;
+  clubMembers: Member[];
+};
+
 export type Member = {
   id?: number;
   name: string;


### PR DESCRIPTION
## 🔥 연관 이슈

- close #206  

## 🚀 작업 내용

- 기존에 동아리 정보 조회 API에 속해 있던 동아리원 명단이 API가 따로 생김으로써 변경 진행하였습니다.
**as is** - API 분리 전 동아리 정보 조회 API
```
{
  "name": "동아리명",
  "category": "사회연구",
  "tag": "IT",
  "leader": "홍길동",
  "phoneNumber": "010-1234-5678",
  "location": "S1111",
  "startRecruitPeriod": "2024-10-15T07:08:25.493Z",
  "endRecruitPeriod": "2024-10-15T07:08:25.493Z",
  ...
  "members": 
    [
      {
        "id": 1,
        "name": "홍길동",
        "studentNumber": "60001111",
        "phoneNumber": "010-1234-5678",
        "position": "LEADER",
        "department": "학과난"
        }, 
      // 여러 개
   ]
  }
```
**to be** - API 분리 후 동아리원 명단 API
```
{
  "clubName": "COW",
  "clubMembers": 
    [
      {
      "id": 1,
      "name": "홍길동",
      "studentNumber": "60001111",
      "phoneNumber": "010-1234-5678",
      "position": "LEADER",
      "department": "학과난"
      },
      // 여러 개
    ]
}
```
- `getMemberFile` API 엔드포인트 `centarl`로 변경하였습니다.
- `ColorSelect`에 불필요한 상태도 제거했습니다.

## 💬 리뷰 중점사항
