### PR TITLE
다중 이미지의 순서 보장 기능

### DIFF
--- a/src/components/fix/FixDetail.tsx
+++ b/src/components/fix/FixDetail.tsx
@@ -8,6 +8,7 @@ import { ROLE_TYPE } from '@/constants/text';
 import { useFixInfo } from '@/hooks/api/fixzone/useFixInfo';
 import { useUpdateComplete } from '@/hooks/api/fixzone/useUpdateComplete';
 import useModal from '@/hooks/common/useModal';
+import { sortByOrder } from '@/utils/change';
 import CommentContainer from './comment/CommentContainer';
 import FixItemInfo from './FixItemInfo';
 import Heading from '../common/Heading';
@@ -40,6 +41,7 @@ export default function FixDetail({ id }: Prop) {
     title,
     content,
   } = data;
+  const sortedImages = sortByOrder(images);
 
   function handleCompleted() {
     setIsCompleted(true);
@@ -74,7 +76,7 @@ export default function FixDetail({ id }: Prop) {
         </div>
         {/* 내용 */}
         <div className="relative flex w-full items-center justify-center md:w-1/2 md:p-3">
-          {images.length === 0 ? (
+          {sortedImages.length === 0 ? (
             <div className="flex min-h-40 w-full items-center justify-center rounded-lg border text-gray-500">
               등록된 사진이 없습니다.
             </div>
@@ -92,7 +94,7 @@ export default function FixDetail({ id }: Prop) {
               ${presentIndex === 0 && 'hidden'}`}
               />
               <Image
-                src={images[presentIndex].originUrl}
+                src={sortedImages[presentIndex].originUrl}
                 width={550}
                 height={500}
                 priority
@@ -108,7 +110,7 @@ export default function FixDetail({ id }: Prop) {
                   setPresentIndex(presentIndex + 1);
                 }}
                 className={`absolute right-2 z-10 mx-3 rounded-3xl bg-slate-100  opacity-50 transition-all duration-300 ease-in-out hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-25 ${
-                  presentIndex === images.length - 1 && `hidden`
+                  presentIndex === sortedImages.length - 1 && `hidden`
                 }`}
               />
             </>

--- a/src/pages/admin/fix/new/index.tsx
+++ b/src/pages/admin/fix/new/index.tsx
@@ -7,18 +7,22 @@ import UploadMultipleImage from '@/components/common/UploadMultipleImage';
 import { useNewFix } from '@/hooks/api/fixzone/useNewFix';
 import { usePresignedUrl } from '@/hooks/common/usePresignedUrl';
 import { EditFix } from '@/types/fix';
+import { createImageOrder } from '@/utils/change';
 
 export default function Index() {
   const mutation = useNewFix();
   const [{ token }] = useCookies(['token']);
   const [post, setPost] = useState<EditFix>(initPost);
+  const { getPresignedIds, isLoading } = usePresignedUrl();
 
   function handleSubmit() {
     if (post.title === '') return toast('제목을 입력해주세요.');
-    mutation.mutate({ post, token });
+    const submitData = {
+      ...post,
+      images: createImageOrder(post.images),
+    };
+    mutation.mutate({ post: submitData, token });
   }
-
-  const { getPresignedIds, isLoading } = usePresignedUrl();
 
   function handleChange(event: ChangeEvent<HTMLTextAreaElement>) {
     setPost((prev: EditFix) => ({
@@ -28,12 +32,12 @@ export default function Index() {
   }
 
   const handleClickDelete = (index: number) => {
-    const revertedIds = (post.fixZoneImageIds as string[])?.filter(
+    const revertedIds = (post.images as string[])?.filter(
       (_, i) => i !== index,
     );
     setPost((prev) => ({
       ...prev,
-      fixZoneImageIds: revertedIds.length === 0 ? null : revertedIds,
+      images: revertedIds.length === 0 ? null : revertedIds,
     }));
   };
 
@@ -42,10 +46,7 @@ export default function Index() {
     const uploadIds = uploadInfo.map(({ id }) => id);
     setPost((prev) => ({
       ...prev,
-      fixZoneImageIds:
-        prev.fixZoneImageIds === null
-          ? uploadIds
-          : [...prev.fixZoneImageIds, ...uploadIds],
+      images: prev.images === null ? uploadIds : [...prev.images, ...uploadIds],
     }));
     return uploadInfo;
   };
@@ -105,5 +106,5 @@ export default function Index() {
 const initPost: EditFix = {
   title: '',
   content: '',
-  fixZoneImageIds: null,
+  images: null,
 };

--- a/src/pages/admin/notice/[id]/index.tsx
+++ b/src/pages/admin/notice/[id]/index.tsx
@@ -16,6 +16,7 @@ import { useNoticeInfo } from '@/hooks/api/notice/useNoticeInfo';
 import { useUpdateNotice } from '@/hooks/api/notice/useUpdateNotice';
 import { usePresignedUrl } from '@/hooks/common/usePresignedUrl';
 import { NoticeDetail } from '@/types/notice';
+import { createImageOrder, sortByOrder } from '@/utils/change';
 
 type NoticeDetailProps = {
   noticeId: number;
@@ -49,8 +50,10 @@ export default function Index({ noticeId }: NoticeDetailProps) {
   useEffect(() => {
     if (data) {
       setNoticeData(data);
-      setFileIds(data.files.map((file) => file.id as string));
-      setImageIds(data.images.map((file) => file.id as string));
+      const sortedImages = sortByOrder(data.images);
+      const sortedFiles = sortByOrder(data.files);
+      setFileIds(sortedFiles.map((file) => file.id as string));
+      setImageIds(sortedImages.map((file) => file.id as string));
     }
   }, [data]);
 
@@ -139,11 +142,13 @@ export default function Index({ noticeId }: NoticeDetailProps) {
       noticeId: noticeId,
       title: noticeData.title,
       content: noticeData.content,
-      fileIds,
-      imageIds,
+      files: createImageOrder(fileIds),
+      images: createImageOrder(imageIds),
       token: token,
     });
   }
+  const sortedImages = sortByOrder(noticeData.images);
+  const sortedFiles = sortByOrder(noticeData.files);
 
   return (
     <>
@@ -200,7 +205,7 @@ export default function Index({ noticeId }: NoticeDetailProps) {
             isLoading={isImageLoading}
             onAdd={handleUploadImage}
             onDelete={handleClickImageDelete}
-            initialImages={noticeData.images}
+            initialImages={sortedImages}
           />
           <TextareaAutosize
             name="content"
@@ -213,7 +218,7 @@ export default function Index({ noticeId }: NoticeDetailProps) {
         </>
       ) : (
         <>
-          {noticeData.images.length > 0 && (
+          {sortedImages.length > 0 && (
             <>
               <div className="relative m-auto mt-5 flex h-96 w-96 items-center justify-center overflow-hidden rounded-xl p-5 shadow-xl md:h-128 md:w-128">
                 {presentIndex > 0 && (
@@ -226,9 +231,9 @@ export default function Index({ noticeId }: NoticeDetailProps) {
                     className="absolute left-2 top-1/2 z-10 -translate-y-1/2 cursor-pointer rounded-3xl bg-slate-100 opacity-50 transition-all duration-300 ease-in-out hover:opacity-100"
                   />
                 )}
-                {noticeData.images[presentIndex] && (
+                {sortedImages[presentIndex] && (
                   <Image
-                    src={noticeData.images[presentIndex]?.originUrl}
+                    src={sortedImages[presentIndex]?.originUrl}
                     width={550}
                     height={500}
                     priority
@@ -236,7 +241,7 @@ export default function Index({ noticeId }: NoticeDetailProps) {
                     className="max-h-full max-w-full object-contain"
                   />
                 )}
-                {presentIndex < noticeData.images.length - 1 && (
+                {presentIndex < sortedImages.length - 1 && (
                   <Image
                     src={RightArrow}
                     width={30}
@@ -264,12 +269,12 @@ export default function Index({ noticeId }: NoticeDetailProps) {
           isLoading={isFileLoading}
           onAdd={handleClickFileAdd}
           onDelete={handleClickFileDelete}
-          initialFiles={noticeData.files}
+          initialFiles={sortedFiles}
         />
       ) : (
         <>
           <div className="py-8 text-sm font-medium text-gray-500 md:py-10 md:text-base">
-            {noticeData.files.map((item, idx) => (
+            {sortedFiles.map((item, idx) => (
               <div key={`notice-file-${idx}`} className="flex gap-3">
                 <Image src={ClipIcon} width={10} height={10} alt="file" />
                 <a href={item.originUrl} download target="_blank">

--- a/src/pages/admin/notice/new/index.tsx
+++ b/src/pages/admin/notice/new/index.tsx
@@ -6,6 +6,7 @@ import UploadMultipleFile from '@/components/common/UploadMultipleFiles';
 import UploadMultipleImage from '@/components/common/UploadMultipleImage';
 import { useNewNotice } from '@/hooks/api/notice/useNewNotice';
 import { usePresignedUrl } from '@/hooks/common/usePresignedUrl';
+import { createImageOrder } from '@/utils/change';
 
 export default function Index() {
   const [title, setTitle] = useState<string>('');
@@ -22,11 +23,12 @@ export default function Index() {
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+
     return mutation.mutate({
       title,
       content,
-      fileIds,
-      imageIds,
+      files: createImageOrder(fileIds),
+      images: createImageOrder(imageIds),
       token,
     });
   }

--- a/src/types/fix.ts
+++ b/src/types/fix.ts
@@ -1,4 +1,4 @@
-import { UrlType } from '.';
+import { OrderUUID, UrlType } from '.';
 
 export type Fix = {
   id: number;
@@ -33,12 +33,14 @@ export type FixComplete = {
 export type EditFix = {
   title: string;
   content: string;
-  fixZoneImageIds: string[] | null;
+  images: string[] | null;
 };
 
 export type NewFix = {
   token: string;
-  post: EditFix;
+  post: Omit<EditFix, 'images'> & {
+    images: OrderUUID[] | null;
+  };
 };
 
 export type NewFixComment = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,10 +52,13 @@ export type PresignedUrlResponse = {
 
 export type UrlType = {
   id?: string;
+  order?: number;
   fileName?: string;
   originUrl: string;
   cdnUrl: string;
 };
+
+export type OrderUUID = { id: string; order: number };
 
 export type Auth = Pick<LoginResponse, 'role' | 'token'>;
 

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,4 +1,4 @@
-import { UrlType } from '.';
+import { OrderUUID, UrlType } from '.';
 
 export type NoticeDetail = {
   id: number;
@@ -23,8 +23,8 @@ export type NoticeTitle = {
 export type NewNotice = {
   title: string;
   content: string;
-  imageIds: string[];
-  fileIds: string[];
+  images: OrderUUID[] | null;
+  files: OrderUUID[] | null;
   token: string;
 };
 

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -1,4 +1,5 @@
 import { RefObject } from 'react';
+import { UrlType } from '@/types';
 import { Fix } from '@/types/fix';
 
 export function sortFixZone(posts: Fix[]): Fix[] {
@@ -19,4 +20,22 @@ export function adjustTextareaHeight(
     textareaRef.current.style.height = 'auto';
     textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
   }
+}
+
+export function createImageOrder(uuids: string[] | null) {
+  if (!uuids) return null;
+  return uuids.map((uuid, index) => ({
+    id: uuid,
+    order: index + 1,
+  }));
+}
+
+export function sortByOrder(urls: UrlType[]) {
+  const hasOrder = (url: UrlType): url is UrlType & { order: number } => {
+    return url.order !== undefined;
+  };
+  if (!urls.every(hasOrder)) {
+    return urls;
+  }
+  return urls.slice().sort((a, b) => a.order - b.order);
 }

--- a/src/utils/change.ts
+++ b/src/utils/change.ts
@@ -31,11 +31,5 @@ export function createImageOrder(uuids: string[] | null) {
 }
 
 export function sortByOrder(urls: UrlType[]) {
-  const hasOrder = (url: UrlType): url is UrlType & { order: number } => {
-    return url.order !== undefined;
-  };
-  if (!urls.every(hasOrder)) {
-    return urls;
-  }
-  return urls.slice().sort((a, b) => a.order - b.order);
+  return urls.slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close #211 

## 🚀 작업 내용
**문제 상황**
[1,2,3,4]순서의 다중이미지 업로드 시, [4,2,3,1]순서로 올라가는 등 이미지 순서를 보장하지않는 문제

- order 속성을 요청/응답 객체에 반영하기 위해 type을 생성/수정했습니다. -> `NewFix`, `NewNotice`, `OrderUUID`, `UrlType`
- 순서 보장 역할을 진행하는 util함수를 생성했습니다.
  - `sortByOrder` : reponse받은 배열을 order순서에 맞춰 정렬
  - `createImageOrder` : uuid의 type을 `string[]`에서 `OrderUUID[]`로 변환
- 다중이미지업로드를 사용하는 동아리방시설보수, 공지사항 도메인에 변경사항을 적용했습니다.

