### PR TITLE
피드 전체 조회 cursor 기반 페이지네이션 적용

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const nextConfig = {
     domains: [
       'ddn4vjj3ws13w.cloudfront.net',
       'd2syrtcctrfiup.cloudfront.net',
+      'ddingdong-converted-file.s3.ap-northeast-2.amazonaws.com',
       'ddingdong-file.s3.ap-northeast-2.amazonaws.com',
       'github.com',
     ],

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -35,7 +35,7 @@ import {
   User,
 } from '@/types/event';
 
-import { Feed, FeedDetail } from '@/types/feed';
+import { Feed, FeedDetail, TotalFeed } from '@/types/feed';
 import {
   DeleteFixComment,
   Fix,
@@ -164,8 +164,12 @@ export async function getDocumentInfo(
   return await api.get(`/documents/${documentId}`);
 }
 
-export async function getAllFeeds(): Promise<AxiosResponse<Feed[], unknown>> {
-  return await api.get('/feeds');
+export async function getAllFeeds(
+  currentCursorId: number | -1,
+): Promise<AxiosResponse<TotalFeed, unknown>> {
+  return await api.get(
+    `/feeds?currentCursorId=${currentCursorId ?? -1}&size=9`,
+  );
 }
 
 export async function getClubFeed(

--- a/src/components/feed/ClubFeed.tsx
+++ b/src/components/feed/ClubFeed.tsx
@@ -47,11 +47,8 @@ export default function ClubFeed({ feeds }: ClubFeedProps) {
             alt={`image-${index + 1}`}
             fill
             priority={index < 10}
-            onLoad={() => handleImageLoad(item.id)}
             style={{ objectFit: 'cover' }}
-            className={`aspect-square ${
-              isImageLoaded(item.id) ? 'visible' : 'invisible'
-            }`}
+            onLoad={() => handleImageLoad(item.id)}
             onClick={() => handleClick(item.id)}
           />
           {item.feedType == 'VIDEO' && (

--- a/src/components/feed/ClubFeed.tsx
+++ b/src/components/feed/ClubFeed.tsx
@@ -12,9 +12,7 @@ type ClubFeedProps = {
 };
 
 export default function ClubFeed({ feeds }: ClubFeedProps) {
-  const [loadedImages, setLoadedImages] = useState<{ [key: number]: boolean }>(
-    {},
-  );
+  const [loadedImages, setLoadedImages] = useState<Record<number, boolean>>({});
   const [feedId, setFeedId] = useState<number>(0);
   const { openModal, visible, closeModal, modalRef } = useModal();
 
@@ -26,6 +24,8 @@ export default function ClubFeed({ feeds }: ClubFeedProps) {
   const handleImageLoad = (id: number) => {
     setLoadedImages((prev) => ({ ...prev, [id]: true }));
   };
+
+  const isImageLoaded = (id: number) => loadedImages[id] || false;
 
   const renderSkeleton = () => (
     <div className="absolute inset-0">
@@ -40,16 +40,17 @@ export default function ClubFeed({ feeds }: ClubFeedProps) {
           key={item.id}
           className="relative flex aspect-square w-full cursor-pointer"
         >
-          {!loadedImages[item.id] && renderSkeleton()}
+          {!isImageLoaded(item.id) && renderSkeleton()}
+
           <Image
-            src={item.thumbnailUrl}
+            src={item.thumbnailCdnUrl}
             alt={`image-${index + 1}`}
-            width={350}
-            height={350}
+            fill
+            priority={index < 10}
             onLoad={() => handleImageLoad(item.id)}
             style={{ objectFit: 'cover' }}
             className={`aspect-square ${
-              loadedImages[item.id] ? 'visible' : 'invisible'
+              isImageLoaded(item.id) ? 'visible' : 'invisible'
             }`}
             onClick={() => handleClick(item.id)}
           />

--- a/src/components/modal/feed/ClubFeedDetail.tsx
+++ b/src/components/modal/feed/ClubFeedDetail.tsx
@@ -24,7 +24,7 @@ export default function ClubFeedDetail({ feedId }: Props) {
     const feed = data.data;
 
     const imageSrc =
-      feed.clubProfile.profileImageUrl?.length > 0
+      feed?.clubProfile.profileImageUrl?.length > 0
         ? parseImgUrl(feed.clubProfile?.profileImageUrl)
         : Admin;
 
@@ -38,16 +38,16 @@ export default function ClubFeedDetail({ feedId }: Props) {
       <div className="flex h-full w-full flex-col ">
         <div
           className={`${
-            feed.feedType === 'VIDEO' ? 'h-full ' : 'h-[225px]'
+            feed?.feedType === 'VIDEO' ? 'h-full ' : 'h-[225px]'
           } relative  w-full rounded-t-lg bg-black md:h-[450px]`}
         >
-          {feed.feedType === 'VIDEO' ? (
-            <VideoPlayer videoUrl={feed.fileUrl} />
+          {feed?.feedType === 'VIDEO' ? (
+            <VideoPlayer videoUrl={feed.fileUrls.cdnUrl} />
           ) : (
             <>
               {!loadedImages && renderSkeleton()}
               <Image
-                src={feed.fileUrl}
+                src={feed?.fileUrls.originUrl}
                 alt={'동아리 피드'}
                 height={450}
                 width={450}
@@ -59,7 +59,7 @@ export default function ClubFeedDetail({ feedId }: Props) {
         </div>
         <div className="ml-5 flex h-[17vh] flex-col items-start justify-center md:ml-10 ">
           <Link
-            href={location ? `/club/${feed.clubProfile.id}` : '#'}
+            href={location ? `/club/${feed?.clubProfile.id}` : '#'}
             className="flex items-center text-base font-semibold md:text-2xl"
           >
             <Image
@@ -70,14 +70,14 @@ export default function ClubFeedDetail({ feedId }: Props) {
               priority
               className="m-auto mr-3 h-12 w-12 rounded-full border-[1.5px] object-cover md:h-14 md:w-14"
             />
-            {feed.clubProfile.name}
+            {feed?.clubProfile.name}
           </Link>
 
           <div className="my-1 text-base font-medium md:text-xl">
-            {feed.activityContent}
+            {feed?.activityContent}
           </div>
           <div className="font-base md:text-md text-base text-gray-500 ">
-            {feed.createdDate}
+            {feed?.createdDate}
           </div>
         </div>
       </div>

--- a/src/hooks/api/feed/useAllFeeds.ts
+++ b/src/hooks/api/feed/useAllFeeds.ts
@@ -1,16 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
-import { AxiosError, type AxiosResponse } from 'axios';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { type AxiosResponse } from 'axios';
 import { getAllFeeds } from '@/apis';
-import { Feed } from '@/types/feed';
+import { TotalFeed } from '@/types/feed';
 
 export function useAllFeeds() {
-  return useQuery<
-    unknown,
-    AxiosError,
-    AxiosResponse<Feed[], unknown>,
-    [string]
-  >({
+  return useInfiniteQuery<AxiosResponse<TotalFeed>>({
     queryKey: ['feeds'],
-    queryFn: getAllFeeds,
+    queryFn: ({ pageParam = -1 }) => getAllFeeds(pageParam),
+    getNextPageParam: (lastPage) => {
+      if (lastPage.data.pagingInfo?.hasNext) {
+        return lastPage.data.pagingInfo.nextCursorId;
+      }
+      return undefined;
+    },
   });
 }

--- a/src/pages/feeds/index.tsx
+++ b/src/pages/feeds/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import Head from 'next/head';
 import ClubFeed from '@/components/feed/ClubFeed';
+import Loading from '@/components/loading/Loading';
 import { useAllFeeds } from '@/hooks/api/feed/useAllFeeds';
 
 const OBSERVER_OPTIONS = {
@@ -11,7 +12,7 @@ const OBSERVER_OPTIONS = {
 
 export default function Index() {
   const observerTarget = useRef<HTMLDivElement>(null);
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useAllFeeds();
 
   const feeds = data?.pages.flatMap((page) => page.data.newestFeeds) ?? [];
@@ -35,6 +36,14 @@ export default function Index() {
     }
     return () => observer.disconnect();
   }, [handleObserver]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <Loading />
+      </div>
+    );
+  }
 
   return (
     <>

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -1,3 +1,4 @@
+import { UrlType } from '.';
 import { ClubProfile } from './club';
 
 export type TabMenu = {
@@ -5,17 +6,29 @@ export type TabMenu = {
   content: JSX.Element;
 };
 
+export type TotalFeed = {
+  newestFeeds: Feed[];
+  pagingInfo: PagingInfo;
+};
+
 export type Feed = {
   id: number;
-  thumbnailUrl: string;
   feedType?: string;
+  thumbnailCdnUrl: string;
+  thumbnailOriginUrl: string;
 };
 
 export type FeedDetail = {
   id: number;
-  clubProfile: ClubProfile;
-  activityContent: string;
-  fileUrl: string;
   feedType: 'IMAGE' | 'VIDEO';
+  activityContent: string;
+  fileUrls: UrlType;
   createdDate: string;
+  clubProfile: ClubProfile;
+};
+
+export type PagingInfo = {
+  hasNext: boolean;
+  nextCursorId: number;
+  currentCursorId: number;
 };


### PR DESCRIPTION
## 🔥 연관 이슈

- close #213 

## 🚀 작업 내용

- `IntersectionObserver` API 사용해서 피드 전체 조회 cursor 기반 페이지네이션 적용했습니다.
  - `IntersectionObserver`는 특정 요소가 뷰포트에 진입하거나 나갈 때를 감지할 수 있는 API에요. 해당 객체를 활용해서  페이지 하단에 위치한 `observerTarget` 요소가 뷰포트에 들어올 때 `fetchNextPage`를 호출해 추가 데이터를 요청하는 무한 스크롤을 구현했어요.

https://github.com/user-attachments/assets/fbcfe6ab-9d20-48bc-9c56-c744f92660a3

- 변경된 커서 기반 API는 초기에는 `currentCursorId` 을 `-1` 로 요청을 보내고, 이후부터는 응답에 포함된 `currentCursorId`를 포함해서 요청을 보내요. `hasNext`이 `false`일 경우 요청을 보내지 않습니다. 
- 가독성과 유지보수성을 위해 기존의 `{ [key: number]: boolean }` 해당 타입에서 `Record` 유틸리티 타입을 사용하여 `<Record<number, boolean>>`로 변경했습니다.
