### PR TITLE
banner 바로가기 버튼 style 변경

### DIFF
--- a/src/constants/text.tsx
+++ b/src/constants/text.tsx
@@ -24,6 +24,7 @@ type RoleText = {
     documents: NavBox;
     FAQ?: NavBox;
     feed: NavBox;
+    banner?: NavBox;
   };
 };
 
@@ -62,6 +63,11 @@ export const ROLE_TEXT: RoleText = {
       title: '동아리 피드 업로드',
       subtitle: '동아리의 활동 사진 및 영상을 업로드하고 홍보해요.',
       route: '/feed',
+    },
+    banner: {
+      title: '배너 관리',
+      subtitle: '띵동의 모바일/웹 버전 배너를 관리해요',
+      route: '/banner',
     },
   },
   [ROLE_TYPE.ROLE_CLUB]: {

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -169,6 +169,19 @@ export default function Index() {
             </div>
           </Link>
         )}
+        {role === ROLE_TYPE.ROLE_ADMIN && ROLE_TEXT[role]?.banner && (
+          <Link
+            href={ROLE_TEXT[role].banner.route}
+            className=" inline-block min-h-[7rem] w-full rounded-xl border-[1.5px] px-6 py-5 transition-colors hover:border-gray-300 hover:bg-gray-50 md:min-h-[8.5rem] md:px-8 md:py-7"
+          >
+            <h2 className="text-xl font-bold md:text-2xl">
+              {ROLE_TEXT[role].banner.title}
+            </h2>
+            <div className="mt-2 text-sm font-semibold leading-tight text-gray-400 md:mt-3 md:text-base md:leading-tight">
+              <p>{ROLE_TEXT[role].banner.subtitle}</p>
+            </div>
+          </Link>
+        )}
       </div>
       <div className="mt-4 w-full rounded-xl border-[1.5px] p-6 md:mt-8 md:p-8">
         <div className="flex w-full items-center justify-between">

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -169,16 +169,16 @@ export default function Index() {
             </div>
           </Link>
         )}
-        {role === ROLE_TYPE.ROLE_ADMIN && ROLE_TEXT[role]?.banner && (
+        {role === ROLE_TYPE.ROLE_ADMIN && (
           <Link
-            href={ROLE_TEXT[role].banner.route}
+            href={ROLE_TEXT[role]?.banner?.route ?? ''}
             className=" inline-block min-h-[7rem] w-full rounded-xl border-[1.5px] px-6 py-5 transition-colors hover:border-gray-300 hover:bg-gray-50 md:min-h-[8.5rem] md:px-8 md:py-7"
           >
             <h2 className="text-xl font-bold md:text-2xl">
-              {ROLE_TEXT[role].banner.title}
+              {ROLE_TEXT[role]?.banner?.title ?? ''}
             </h2>
             <div className="mt-2 text-sm font-semibold leading-tight text-gray-400 md:mt-3 md:text-base md:leading-tight">
-              <p>{ROLE_TEXT[role].banner.subtitle}</p>
+              <p>{ROLE_TEXT[role]?.banner?.subtitle ?? ''}</p>
             </div>
           </Link>
         )}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useCookies } from 'react-cookie';
-import Write from '@/assets/write.svg';
 import AdminHeading from '@/components/admin/AdminHeading';
 import Slider from '@/components/common/Slider';
 import { ROLE_TEXT, ROLE_TYPE } from '@/constants/text';
@@ -70,21 +68,6 @@ export default function Index() {
         {infoElement}
       </div>
       <div className="relative mt-7">
-        <Link
-          href="/banner"
-          className={`absolute right-2 top-6 z-10 inline-block w-12 p-2 opacity-40 transition-opacity hover:opacity-70  ${
-            role === ROLE_TYPE.ROLE_CLUB && 'invisible'
-          }`}
-        >
-          <Image
-            src={Write}
-            width={100}
-            height={100}
-            priority
-            alt="banner"
-            className="w-5"
-          />
-        </Link>
         <Slider />
       </div>
       <div className="mt-2 grid w-full grid-cols-1 gap-3 sm:grid-cols-3 md:mt-6 md:gap-5">


### PR DESCRIPTION
## 🔥 연관 이슈

- close #220 

## 🚀 작업 내용
- banner 바로가기 버튼 style변경 진행

**문제**
- 이미지 크기 변동에 따라 **이미지 수정 버튼**의 레이아웃이 깨지는 부분이 있어, 아래 절차를 진행했습니다.
1. 편집 버튼을 제거
2. 바로가기 영역 생성

as is
<img width="500" alt="스크린샷 2025-01-22 오후 4 26 17" src="https://github.com/user-attachments/assets/2f42e480-885c-4475-9d74-822f5ea4bdc5" />

to be
<img width="500" alt="스크린샷 2025-01-22 오후 4 27 09" src="https://github.com/user-attachments/assets/f676b18e-6999-44c9-9bbc-9dbb86ac0afb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 관리자 역할에 대한 배너 관리 탐색 옵션 추가
	- 사용자 역할에 따른 탐색 메뉴 구조 업데이트

- **UI 변경**
	- 클럽 역할 사용자의 기존 링크 제거
	- 관리자 역할 사용자를 위한 새로운 배너 섹션 링크 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->