### PR TITLE
동아리 피드 SSE, 피드 생성 로직 수정

### DIFF
--- a/src/components/admin/AdminHeading.tsx
+++ b/src/components/admin/AdminHeading.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
 import { useMyClub } from '@/hooks/api/club/useMyClub';
 import { useClubStore } from '@/store/club';
@@ -5,7 +6,13 @@ import { useClubStore } from '@/store/club';
 export default function AdminHeading() {
   const [{ token }] = useCookies(['token']);
   const { data } = useMyClub(token);
-  useClubStore((state) => state.setClub);
+  const setClub = useClubStore((state) => state.setClub);
+
+  useEffect(() => {
+    if (data?.data) {
+      setClub(data.data);
+    }
+  }, [data, setClub]);
 
   return (
     <div className="flex w-full items-end justify-between">

--- a/src/components/admin/AdminHeading.tsx
+++ b/src/components/admin/AdminHeading.tsx
@@ -5,11 +5,7 @@ import { useClubStore } from '@/store/club';
 export default function AdminHeading() {
   const [{ token }] = useCookies(['token']);
   const { data } = useMyClub(token);
-  const setClub = useClubStore((state) => state.setClub);
-
-  if (data) {
-    setClub(data.data);
-  }
+  useClubStore((state) => state.setClub);
 
   return (
     <div className="flex w-full items-end justify-between">

--- a/src/components/common/UploadMedia.tsx
+++ b/src/components/common/UploadMedia.tsx
@@ -71,7 +71,7 @@ export default function UploadMedia({ onAdd, isLoading }: Props) {
             <Image src={Camera} width={30} height={30} alt="upload" />
             <p className="m-2 text-sm">Click to ImageUpload</p>
             <p className=" text-xs text-gray-400">
-              * 파일 용량은 최대 500MB / 4분까지 업로드 가능합니다.
+              * 파일 용량은 최대 300MB까지 업로드 가능합니다.
             </p>
           </div>
           <input

--- a/src/hooks/api/feed/useNewFeed.ts
+++ b/src/hooks/api/feed/useNewFeed.ts
@@ -22,8 +22,8 @@ export function useNewFeed(): UseMutationResult<
       queryClient.invalidateQueries(['feed']);
       if (!variables.mimeType?.includes('video')) {
         toast.success('피드가 생성되었어요.');
+        router.push('/');
       }
-      router.push('/');
     },
     onError(error) {
       const errorMessage = error.response?.data?.message

--- a/src/pages/admin/feed/new/index.tsx
+++ b/src/pages/admin/feed/new/index.tsx
@@ -49,14 +49,10 @@ export default function Index() {
 
   function handleSubmit() {
     if (feedData.mimeType?.includes('video')) {
-      mutation.mutate(
-        { ...feedData, token },
-        {
-          onSuccess: () => {
-            subscribeToSSE(token, feedData.mediaId);
-          },
-        },
+      subscribeToSSE(token, feedData.mediaId, () =>
+        mutation.mutate({ ...feedData, token }),
       );
+      router.push('/');
       return;
     }
     mutation.mutate({ ...feedData, token });

--- a/src/utils/subscribeToSSE.tsx
+++ b/src/utils/subscribeToSSE.tsx
@@ -2,7 +2,11 @@ import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
 import toast from 'react-hot-toast';
 import { useUploadStore } from '@/store/upload';
 
-export function subscribeToSSE(token: string, mediaId: string) {
+export function subscribeToSSE(
+  token: string,
+  mediaId: string,
+  createFeed: () => void,
+) {
   const { setVideoUploading, removeVideoUpload } = useUploadStore.getState();
   const EventSource = EventSourcePolyfill || NativeEventSource;
 
@@ -23,6 +27,7 @@ export function subscribeToSSE(token: string, mediaId: string) {
   eventSource.addEventListener('connect', (event) => {
     if ((event as MessageEvent).data === 'Connected successfully!') {
       toast.loading('비디오 업로드 중입니다.', { id: toastId });
+      createFeed();
     }
   });
 
@@ -30,7 +35,7 @@ export function subscribeToSSE(token: string, mediaId: string) {
     const messageEvent = event as MessageEvent;
     const parsedData = JSON.parse(messageEvent.data);
     if (parsedData.data.convertJobStatus === 'COMPLETE') {
-      toast.success('비디오 업로드가 완료되었습니다!', { id: toastId });
+      toast.success('피드가 생성되었어요.', { id: toastId });
       removeVideoUpload(mediaId);
       eventSource.close();
     }


### PR DESCRIPTION
## 🔥 연관 이슈

- close #223 

## 🚀 작업 내용

- 기존에는 호출 순서가 아래와 같아요. 이미지/동영상이 업로드 되면 바로 미디어 컨버팅 작업이 시작되어 짧은 동영상(혹은 사용자가 업로드 후 `/feed/new` 페이지에 오래 머무를 경우) 인 경우 알람을 제대로 받지 못하는 문제 상황이 존재했어요.
- 변경된 사항은 SSE 연결을 먼저 시도하고, 연결에 성공한 후 피드를 생성하는 방식으로 변경되었습니다.  

### as is
`이미지 업로드` - `presignedUrl 작업` - `미디어 컨버팅 작업` - `**작업 완료 후 알람 (아직 SSE 연결 X)**` -`피드 생성` - `SSE 호출` - `작업 완료 후 알람`

### to be
`이미지 업로드` - `presignedUrl 작업` - `미디어 컨버팅 작업` - `**작업 완료 후 알람 (아직 SSE 연결 X)**` - `SSE 호출 및 연결 완료` -`피드 생성(알람 재시도)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 파일 업로드 제한 사항 업데이트 (최대 파일 크기 300MB로 변경)
	- 피드 생성 및 SSE(Server-Sent Events) 구독 프로세스 개선

- **버그 수정**
	- 비디오 콘텐츠에 대한 라우팅 로직 최적화
	- 피드 생성 시 조건부 탐색 메커니즘 추가

- **사용자 경험**
	- 업로드 안내 문구 업데이트
	- 피드 생성 완료 메시지 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->