### PR TITLE
Next Image 태그 변경

### DIFF
--- a/src/components/club/ClubHeading.tsx
+++ b/src/components/club/ClubHeading.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import dayjs from 'dayjs';
 import Admin from '@/assets/admin.jpg';
@@ -46,15 +47,12 @@ export default function ClubHeading({ info }: ClubHeadingProps) {
       <div className="flex flex-col">
         <div className="flex flex-row items-end">
           <div className="h-14 w-14 overflow-hidden rounded-full border-[1.5px] border-gray-100 md:h-20 md:w-20">
-            {
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={profileImage?.originUrl ?? Admin.src}
-                alt="admin"
-                width={80}
-                height={80}
-              />
-            }
+            <Image
+              src={profileImage?.originUrl ?? Admin.src}
+              alt="admin"
+              width={80}
+              height={80}
+            />
           </div>
           <div className="ml-3">
             <Heading>{name}</Heading>

--- a/src/components/club/ClubInfo.tsx
+++ b/src/components/club/ClubInfo.tsx
@@ -55,12 +55,11 @@ export default function ClubInfo({
             동아리 소개 이미지
           </div>
           {introductionImageUrl?.originUrl && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <Image
               src={introductionImageUrl?.originUrl}
-              // width={1000}
-              // height={500}
-              // priority
+              width={1000}
+              height={500}
+              priority
               alt="동아리 소개 사진"
               className={`${
                 !introductionImageUrl && `hidden`

--- a/src/components/feed/ClubFeed.tsx
+++ b/src/components/feed/ClubFeed.tsx
@@ -79,19 +79,16 @@ export default function ClubFeed({
               className="absolute left-2 top-2 md:h-8 md:w-8"
             />
           )}
-          {
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              width={350}
-              height={350}
-              src={item.thumbnailCdnUrl}
-              alt={`image-${index + 1}`}
-              // priority={index < 10}
-              style={{ objectFit: 'cover' }}
-              className="aspect-square"
-              onLoad={() => handleImageLoad(item.id)}
-            />
-          }
+          <Image
+            width={350}
+            height={350}
+            src={item.thumbnailCdnUrl}
+            alt={`image-${index + 1}`}
+            priority={index < 10}
+            style={{ objectFit: 'cover' }}
+            className="aspect-square"
+            onLoad={() => handleImageLoad(item.id)}
+          />
           {item.feedType == 'VIDEO' && (
             <Image
               width={20}

--- a/src/components/layout/UserHeader.tsx
+++ b/src/components/layout/UserHeader.tsx
@@ -59,12 +59,11 @@ export default function UserHeader() {
     return (
       <div className="flex w-full items-center justify-between px-6">
         <Link href="/" className="inline-block">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+          <Image
             src={'/logo.png'}
             width={1544}
             height={380}
-            // priority
+            priority
             alt="ddingdong"
             className="w-32"
           />
@@ -147,12 +146,11 @@ export default function UserHeader() {
           ref={dropdownRef}
         >
           <Link href="/">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src={'/logo.png'}
               width={1544}
               height={380}
-              // priority
+              priority
               alt="ddingdong"
               className="w-40 md:w-44"
             />

--- a/src/components/modal/feed/ClubFeedDetail.tsx
+++ b/src/components/modal/feed/ClubFeedDetail.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -23,10 +22,6 @@ export default function ClubFeedDetail({ feedId }: Props) {
 
   if (isSuccess) {
     const feed = data.data;
-
-    // const imageSrc = feed?.clubProfile.profileImageCdnUrl
-    //   ? feed.clubProfile?.profileImageCdnUrl
-    //   : Admin;
 
     const renderSkeleton = () => (
       <div className="absolute inset-0">

--- a/src/components/modal/feed/ClubFeedDetail.tsx
+++ b/src/components/modal/feed/ClubFeedDetail.tsx
@@ -46,7 +46,7 @@ export default function ClubFeedDetail({ feedId }: Props) {
           ) : (
             <>
               {!loadedImages && renderSkeleton()}
-              <img
+              <Image
                 src={feed?.fileUrls.cdnUrl}
                 alt={'동아리 피드'}
                 height={450}
@@ -63,12 +63,12 @@ export default function ClubFeedDetail({ feedId }: Props) {
               href={location ? `/club/${feed?.clubProfile.id}` : '#'}
               className="flex items-center text-base font-semibold md:text-2xl"
             >
-              <img
+              <Image
                 src={data.data.clubProfile?.profileImageCdnUrl ?? Admin.src}
                 alt={'동아리 대표 이미지'}
                 width={80}
                 height={80}
-                // priority
+                priority
                 className="m-auto mr-3 h-12 w-12 rounded-full border-[1.5px] object-cover md:h-14 md:w-14"
               />
               {feed?.clubProfile.name}

--- a/src/hooks/api/apply/useApplicantInfo.ts
+++ b/src/hooks/api/apply/useApplicantInfo.ts
@@ -1,6 +1,5 @@
-/* eslint-disable import/named */
 import { useQuery } from '@tanstack/react-query';
-import { AxiosError, AxiosResponse } from 'axios';
+import { AxiosError, type AxiosResponse } from 'axios';
 import { getApplicantInfo } from '@/apis';
 import { ApplicantDetail } from '@/types/apply';
 

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -203,7 +203,6 @@ export default function Index() {
           </h2>
           <Link
             href={ROLE_TEXT[role].notice.route}
-            // eslint-disable-next-line prettier/prettier
             className="-mr-1 inline-block p-1 text-sm font-semibold text-gray-400 transition-colors hover:text-blue-500 md:text-base"
           >
             더 보기
@@ -243,7 +242,6 @@ export default function Index() {
             </h2>
             <Link
               href={ROLE_TEXT[role].documents.route}
-              // eslint-disable-next-line prettier/prettier
               className="-mr-1 inline-block p-1 text-sm font-semibold text-gray-400 transition-colors hover:text-blue-500 md:text-base"
             >
               더 보기

--- a/src/pages/admin/login/index.tsx
+++ b/src/pages/admin/login/index.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable import/named */
 import { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { AxiosResponse } from 'axios';
+import { type AxiosResponse } from 'axios';
 import { useCookies } from 'react-cookie';
 import toast from 'react-hot-toast';
 import { login } from '@/apis';
@@ -15,7 +14,6 @@ export default function Index() {
   const router = useRouter();
   const [id, setId] = useState<string>('');
   const [pw, setPw] = useState<string>('');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [cookie, setCookie, removeCookie] = useCookies([
     'token',
     'role',


### PR DESCRIPTION
## 🔥 연관 이슈

- close #247

## 🚀 작업 내용

- vercel 이슈가 존재해서 임시로 `img`태그를 사용했었어요. vercel pro로 업그레이드를 진행하며 이슈가 해결되었고 따라서 Next `Image` 태그로 변환하는 작업을 진행했습니다. 

<img width="398" alt="image" src="https://github.com/user-attachments/assets/b9d65d61-988f-42bc-aaa3-4d918363ac84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **신규 기능**
  - 여러 사용자 인터페이스에서 이미지 표시 방식을 개선하여 로딩 속도와 성능이 향상되었습니다. 이번 업데이트는 프로필, 피드, 헤더 등 다양한 화면에서 최적화된 이미지 처리를 제공함으로써 보다 원활한 사용자 경험을 보장합니다.
- **버그 수정**
  - 불필요한 ESLint 규칙 비활성화 주석이 제거되어 코드가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->