### PR TITLE
전년도 통계 비율 반영로직 개선

### DIFF
--- a/src/components/apply/QuestionMultipleContent.tsx
+++ b/src/components/apply/QuestionMultipleContent.tsx
@@ -28,7 +28,7 @@ export default function QuestionMultipleContent({ type, id }: Props) {
           className="md:px-3 md:py-2 md:text-sm"
         />
       </div>
-      <ChartComponent passedData={data?.data.options ?? []} />
+      <ChartComponent data={data?.data.options ?? []} />
     </div>
   );
 }

--- a/src/components/apply/StatisticsIntro.tsx
+++ b/src/components/apply/StatisticsIntro.tsx
@@ -69,11 +69,11 @@ export default function StatisticsIntro({ applyId }: Props) {
     );
   };
 
-  const getApplicantStatistics = (passedData: ApplyRate[]): ApplyRate[] => {
-    if (!isFirstApply) return passedData;
+  const getApplicantStatistics = (data: ApplyRate[]): ApplyRate[] => {
+    if (!isFirstApply) return data;
 
     const clubName = getClubNameFromStorage();
-    return createComparisonData(clubName, passedData);
+    return createComparisonData(clubName, data);
   };
 
   return (

--- a/src/components/apply/StatisticsIntro.tsx
+++ b/src/components/apply/StatisticsIntro.tsx
@@ -11,16 +11,58 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useApplyStatistics } from '@/hooks/api/apply/useApplyStatistics';
-import { ChartItem } from '@/types/apply';
+import { ApplyRate, ChartItem } from '@/types/apply';
+import { MOCK_APPLYCANT } from './applicant.data';
 import OptionModal from '../ui/OptionModal';
 
 type Props = {
   applyId: number;
 };
 
+function calculateCompared(previous: ApplyRate, current: ApplyRate) {
+  const countDifference = current?.count - previous?.count;
+  const ratio =
+    previous?.count === 0
+      ? 0
+      : Number(((countDifference / previous?.count) * 100).toFixed(2));
+
+  return {
+    ...current,
+    comparedToBefore: {
+      ratio: ratio,
+      value: countDifference,
+    },
+  };
+}
+
+const getClubNameFromStorage = (): string => {
+  if (typeof window === 'undefined') return '';
+
+  try {
+    const club = JSON.parse(localStorage.getItem('club') ?? '');
+    return club.state?.club?.name.toUpperCase() ?? '';
+  } catch (error) {
+    console.error('Failed to parse club data from localStorage:', error);
+    return '';
+  }
+};
+
+const isFirstApply = (data: ApplyRate[]): boolean => {
+  return data.length === 1;
+};
+
+const createComparisonData = (
+  clubName: string,
+  passedData: ApplyRate[],
+): ApplyRate[] => {
+  const MOCK_DATA = MOCK_APPLYCANT[clubName];
+  return [MOCK_DATA, calculateCompared(MOCK_DATA, passedData[0])];
+};
+
 export default function StatisticsIntro({ applyId }: Props) {
   const [{ token }] = useCookies(['token']);
   const { data } = useApplyStatistics(applyId, token);
+
   const sortDepartmentRanksByLabel = (): ChartItem[] => {
     if (!data?.data.departmentStatistics) return [];
     return (
@@ -29,10 +71,23 @@ export default function StatisticsIntro({ applyId }: Props) {
       ) ?? data?.data.departmentStatistics
     );
   };
+
+  const getApplicantStatistics = (passedData: ApplyRate[]): ApplyRate[] => {
+    if (!isFirstApply(passedData)) {
+      return passedData;
+    }
+    const clubName = getClubNameFromStorage();
+    return createComparisonData(clubName, passedData);
+  };
+
   return (
     <div className="flex flex-col flex-wrap items-center gap-10 rounded-md border border-[#E5E7EB] p-6 text-base font-semibold text-[#4B5563] md:flex-row md:items-end md:justify-around md:p-8 md:text-xl md:font-bold">
       <section className="max-w-[250px] flex-none md:w-[300px]">
-        <LineChart passedData={data?.data.applicantStatistics ?? []} />
+        <LineChart
+          passedData={getApplicantStatistics(
+            data?.data.applicantStatistics ?? [],
+          )}
+        />
         <div className="m-3 flex justify-center">
           <h2 className="mr-1 text-center">최근 모집 대비 지원자 수</h2>
           <ApplicantAnnounceIcon />

--- a/src/components/apply/StatisticsIntro.tsx
+++ b/src/components/apply/StatisticsIntro.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 
 import { useCookies } from 'react-cookie';
+import toast from 'react-hot-toast';
 import InfoIcon from '@/assets/info.svg';
 import BarChart from '@/components/common/bar-chart';
 import LineChart from '@/components/common/line-chart';
@@ -42,7 +43,7 @@ const getClubNameFromStorage = (): string => {
     const club = JSON.parse(localStorage.getItem('club') ?? '');
     return club.state?.club?.name.toUpperCase() ?? '';
   } catch (error) {
-    console.error('Failed to parse club data from localStorage:', error);
+    toast.error('동아리 정보를 가져오는데 실패했어요. 다시 로그인해주세요.');
     return '';
   }
 };

--- a/src/components/apply/StatisticsIntro.tsx
+++ b/src/components/apply/StatisticsIntro.tsx
@@ -19,7 +19,7 @@ type Props = {
   applyId: number;
 };
 
-function calculateCompared(previous: ApplyRate, current: ApplyRate) {
+function calculateComparisonData(previous: ApplyRate, current: ApplyRate) {
   const countDifference = current?.count - previous?.count;
   const ratio =
     previous?.count === 0
@@ -47,21 +47,18 @@ const getClubNameFromStorage = (): string => {
   }
 };
 
-const isFirstApply = (data: ApplyRate[]): boolean => {
-  return data.length === 1;
-};
-
 const createComparisonData = (
   clubName: string,
   passedData: ApplyRate[],
 ): ApplyRate[] => {
   const MOCK_DATA = MOCK_APPLYCANT[clubName];
-  return [MOCK_DATA, calculateCompared(MOCK_DATA, passedData[0])];
+  return [MOCK_DATA, calculateComparisonData(MOCK_DATA, passedData[0])];
 };
 
 export default function StatisticsIntro({ applyId }: Props) {
   const [{ token }] = useCookies(['token']);
   const { data } = useApplyStatistics(applyId, token);
+  const isFirstApply = data?.data.applicantStatistics.length === 1;
 
   const sortDepartmentRanksByLabel = (): ChartItem[] => {
     if (!data?.data.departmentStatistics) return [];
@@ -73,9 +70,8 @@ export default function StatisticsIntro({ applyId }: Props) {
   };
 
   const getApplicantStatistics = (passedData: ApplyRate[]): ApplyRate[] => {
-    if (!isFirstApply(passedData)) {
-      return passedData;
-    }
+    if (!isFirstApply) return passedData;
+
     const clubName = getClubNameFromStorage();
     return createComparisonData(clubName, passedData);
   };
@@ -90,7 +86,7 @@ export default function StatisticsIntro({ applyId }: Props) {
         />
         <div className="m-3 flex justify-center">
           <h2 className="mr-1 text-center">최근 모집 대비 지원자 수</h2>
-          <ApplicantAnnounceIcon />
+          {isFirstApply && <ApplicantAnnounceIcon />}
         </div>
       </section>
       <section className="flex shrink flex-col items-center md:w-[400px]">
@@ -127,8 +123,8 @@ function ApplicantAnnounceIcon() {
           className="m-0 flex flex-col gap-0"
         >
           <p className="rounded-md bg-[#EFF6FF] p-2.5 text-xs">
-            신규 기능 개설로 기존(2024.09) <br />
-            동아리원을 이전 동아리원 수로 대체했어요
+            신규 기능 개설로 이전(2024.09) <br />
+            지원자 수는 동아리원 수를 가져왔어요
           </p>
         </TooltipContent>
       </Tooltip>

--- a/src/components/apply/StatisticsIntro.tsx
+++ b/src/components/apply/StatisticsIntro.tsx
@@ -50,10 +50,10 @@ const getClubNameFromStorage = (): string => {
 
 const createComparisonData = (
   clubName: string,
-  passedData: ApplyRate[],
+  data: ApplyRate[],
 ): ApplyRate[] => {
   const MOCK_DATA = MOCK_APPLYCANT[clubName];
-  return [MOCK_DATA, calculateComparisonData(MOCK_DATA, passedData[0])];
+  return [MOCK_DATA, calculateComparisonData(MOCK_DATA, data[0])];
 };
 
 export default function StatisticsIntro({ applyId }: Props) {
@@ -81,9 +81,7 @@ export default function StatisticsIntro({ applyId }: Props) {
     <div className="flex flex-col flex-wrap items-center gap-10 rounded-md border border-[#E5E7EB] p-6 text-base font-semibold text-[#4B5563] md:flex-row md:items-end md:justify-around md:p-8 md:text-xl md:font-bold">
       <section className="max-w-[250px] flex-none md:w-[300px]">
         <LineChart
-          passedData={getApplicantStatistics(
-            data?.data.applicantStatistics ?? [],
-          )}
+          data={getApplicantStatistics(data?.data.applicantStatistics ?? [])}
         />
         <div className="m-3 flex justify-center">
           <h2 className="mr-1 text-center">최근 모집 대비 지원자 수</h2>
@@ -92,7 +90,7 @@ export default function StatisticsIntro({ applyId }: Props) {
       </section>
       <section className="flex shrink flex-col items-center md:w-[400px]">
         <div>
-          <BarChart passedData={sortDepartmentRanksByLabel()} />
+          <BarChart data={sortDepartmentRanksByLabel()} />
         </div>
         <div className="relative flex items-center">
           <h2 className="m-3 text-center">지원 학과 TOP 5</h2>

--- a/src/components/common/bar-chart.tsx
+++ b/src/components/common/bar-chart.tsx
@@ -7,27 +7,27 @@ import { ChartItem } from '@/types/apply';
 ChartJS.register(BarController, BarElement, Tooltip);
 
 type Props = {
-  passedData: ChartItem[];
+  data: ChartItem[];
 };
 
-export default function BarChart({ passedData }: Props) {
-  const isList = passedData.length > 5;
-  return isList ? (
-    <BarList passedData={passedData} />
-  ) : (
-    <BarGraph passedData={passedData} />
+export default function BarChart({ data }: Props) {
+  const isList = data.length > 5;
+  return (
+    <div className="w-full">
+      {isList ? <BarList data={data} /> : <BarGraph data={data} />}
+    </div>
   );
 }
 
-function getColorFromCount(passedData: ChartItem[]) {
-  const sorteCountData = [...passedData].sort((a, b) => b.count - a.count);
+function getColorFromCount(data: ChartItem[]) {
+  const sorteCountData = [...data].sort((a, b) => b.count - a.count);
   const colorMap = sorteCountData.map((item, index) => {
     if (index === 0) return '#3B82F6';
     if (index === 1 || index === 2) return '#DBEAFE';
     return '#E5E7EB';
   });
 
-  const backgroundColors = passedData.map((item) => {
+  const backgroundColors = data.map((item) => {
     const sortedIndex = sorteCountData.findIndex(
       (sortedItem) => sortedItem === item,
     );
@@ -36,7 +36,7 @@ function getColorFromCount(passedData: ChartItem[]) {
   return backgroundColors;
 }
 
-export function BarGraph({ passedData }: Props) {
+export function BarGraph({ data }: Props) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartInstanceRef = useRef<ChartJS | null>(null);
   const getBarThickness = () => {
@@ -57,10 +57,10 @@ export function BarGraph({ passedData }: Props) {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const getChartData = (passedData: ChartItem[], barThickness: number) => {
-    const labels = passedData.map((item) => item.label);
-    const rates = passedData.map((item) => item.ratio);
-    const counts = passedData.map((item) => item.count);
+  const getChartData = (data: ChartItem[], barThickness: number) => {
+    const labels = data.map((item) => item.label);
+    const rates = data.map((item) => item.ratio);
+    const counts = data.map((item) => item.count);
 
     return {
       labels,
@@ -68,7 +68,7 @@ export function BarGraph({ passedData }: Props) {
       datasets: [
         {
           data: rates,
-          backgroundColor: getColorFromCount(passedData),
+          backgroundColor: getColorFromCount(data),
           barThickness,
         },
       ],
@@ -76,8 +76,8 @@ export function BarGraph({ passedData }: Props) {
   };
 
   const chartData = useMemo(
-    () => getChartData(passedData, barThickness),
-    [passedData, barThickness],
+    () => getChartData(data, barThickness),
+    [data, barThickness],
   );
 
   const renderChart = useCallback(() => {
@@ -172,12 +172,12 @@ export function BarGraph({ passedData }: Props) {
   return <canvas ref={canvasRef} className="w-full max-w-[400px]" />;
 }
 
-function BarList({ passedData }: Props) {
-  const itemBorderColors = getColorFromCount(passedData);
+function BarList({ data }: Props) {
+  const itemBorderColors = getColorFromCount(data);
 
   return (
     <div className="z-30 flex w-full flex-col gap-4">
-      {passedData.map((item, index) => (
+      {data.map((item, index) => (
         <div
           key={index}
           className="flex w-full gap-2 rounded-xl border border-[#E5E7EB] bg-white p-5 text-sm text-[#6B7280] outline-none md:text-base"

--- a/src/components/common/line-chart.tsx
+++ b/src/components/common/line-chart.tsx
@@ -11,7 +11,6 @@ import {
 
 import { ApplyRate } from '@/types/apply';
 import { tooltip } from '../../constants/tooltip';
-import { MOCK_APPLYCANT } from '../apply/applicant.data';
 
 ChartJS.register(
   LineController,
@@ -26,44 +25,14 @@ type Props = {
   passedData: ApplyRate[];
 };
 
-function calculateCompared(previous: ApplyRate, current: ApplyRate) {
-  const countDifference = current?.count - previous?.count;
-  const ratio =
-    previous?.count === 0
-      ? 0
-      : Number(((countDifference / previous?.count) * 100).toFixed(2));
-
-  return {
-    ...current,
-    comparedToBefore: {
-      ratio: ratio,
-      value: countDifference,
-    },
-  };
-}
-
 const LineChart = ({ passedData }: Props) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartInstanceRef = useRef<ChartJS | null>(null);
 
   const getChartData = (passedData: ApplyRate[]) => {
-    const club =
-      typeof window !== 'undefined'
-        ? JSON.parse(localStorage.getItem('club') ?? '')
-        : '';
-    const clubName = club.state?.club?.name.toUpperCase() ?? '';
-    const parsedApplicantData = [
-      MOCK_APPLYCANT[clubName],
-      calculateCompared(
-        MOCK_APPLYCANT[clubName],
-        passedData[passedData.length - 1],
-      ),
-    ];
-    const labels = parsedApplicantData.map((item) => item?.label);
-    const datas = parsedApplicantData.map((item) => item?.count);
-    const rates = parsedApplicantData.map(
-      (item) => item?.comparedToBefore.ratio,
-    );
+    const labels = passedData.map((item) => item?.label);
+    const datas = passedData.map((item) => item?.count);
+    const rates = passedData.map((item) => item?.comparedToBefore.ratio);
     return {
       labels,
       rates,

--- a/src/components/common/line-chart.tsx
+++ b/src/components/common/line-chart.tsx
@@ -22,17 +22,17 @@ ChartJS.register(
 );
 
 type Props = {
-  passedData: ApplyRate[];
+  data: ApplyRate[];
 };
 
-const LineChart = ({ passedData }: Props) => {
+const LineChart = ({ data }: Props) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartInstanceRef = useRef<ChartJS | null>(null);
 
-  const getChartData = (passedData: ApplyRate[]) => {
-    const labels = passedData.map((item) => item?.label);
-    const datas = passedData.map((item) => item?.count);
-    const rates = passedData.map((item) => item?.comparedToBefore.ratio);
+  const getChartData = (data: ApplyRate[]) => {
+    const labels = data.map((item) => item?.label);
+    const datas = data.map((item) => item?.count);
+    const rates = data.map((item) => item?.comparedToBefore.ratio);
     return {
       labels,
       rates,
@@ -45,7 +45,7 @@ const LineChart = ({ passedData }: Props) => {
     };
   };
 
-  const chartData = useMemo(() => getChartData(passedData), [passedData]);
+  const chartData = useMemo(() => getChartData(data), [data]);
 
   const renderChart = useCallback(() => {
     const canvasContext = canvasRef.current?.getContext('2d');

--- a/src/components/common/pie-chart.tsx
+++ b/src/components/common/pie-chart.tsx
@@ -13,10 +13,10 @@ import { debounce } from '../ui/utils';
 ChartJS.register(PieController, ArcElement, Tooltip, Legend);
 
 type Props = {
-  passedData: ChartItem[];
+  data: ChartItem[];
 };
 
-const PieChart = ({ passedData }: Props) => {
+const PieChart = ({ data }: Props) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartInstanceRef = useRef<ChartJS | null>(null);
 
@@ -28,13 +28,13 @@ const PieChart = ({ passedData }: Props) => {
     };
   };
 
-  const getChartData = (passedData: ChartItem[]) => {
-    const labels = passedData.map((item) =>
+  const getChartData = (data: ChartItem[]) => {
+    const labels = data.map((item) =>
       item.label.length > 7
         ? `${item.label.slice(0, 6)}... (${item.count}명)`
         : `${item.label} (${item.count}명)`,
     );
-    const ratios = passedData.map((item) => item.ratio);
+    const ratios = data.map((item) => item.ratio);
     return {
       labels,
       ratios,
@@ -46,7 +46,7 @@ const PieChart = ({ passedData }: Props) => {
       ],
     };
   };
-  const chartData = useMemo(() => getChartData(passedData), [passedData]);
+  const chartData = useMemo(() => getChartData(data), [data]);
 
   const handleResize = useMemo(() => {
     const maxSize = 200;


### PR DESCRIPTION
## 🔥 연관 이슈

- close #260 

## 🚀 작업 내용
- [x] 지원자수 선그래프 개선
  - as is
    - 2024-09의 지원자수 + 현재 지원자수
  - to be
    - 최초 모집 : 2024-09 지원자수 + 현재 지원자수
    - 재 모집 : 파싱없이 서버응답값 노출

- [x] 지원자수 안내 아이콘
  -  문구 개선 `신규 기능 개설로 기존(2024.09) 동아리원을 이전 동아리원 수로 대체했어요` -> `신규 기능 개설로 이전(2024.09) 지원자 수는 동아리원 수를 가져왔어요`
  - 최초 지원서 작성시에만 안내 문구 노출
<img width="501" alt="스크린샷 2025-06-29 오후 5 22 33" src="https://github.com/user-attachments/assets/ec688776-1d91-4888-a840-e80e7df4ea2e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지원자 통계 데이터가 한 건만 있을 때, 모의 데이터와 비교하여 차트와 비교 정보를 제공합니다.
  * "첫 지원" 시나리오에서 안내 아이콘과 툴팁이 표시됩니다.

* **개선 사항**
  * 지원자 통계 차트 데이터 준비 과정이 단순화되어, 불필요한 외부 데이터 의존성이 제거되었습니다.
  * 차트 컴포넌트의 데이터 전달 프로퍼티명이 `passedData`에서 `data`로 일관되게 변경되었습니다.
  * 툴팁 문구가 더 명확하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->