### PR TITLE
[FIX] 지원서 날짜 밀림, 지원서 수정 안됨 버그 수정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-07-01 **Commit:** 51b5387c **Branch:** main
+
+## OVERVIEW
+
+Ddingdong FE is a pnpm/Turbo monorepo. The product app is a Next.js 15 App Router package in `apps/web`; the local design system is `packages/shared` and is consumed as `@dds/shared`.
+
+## STRUCTURE
+
+```text
+ddingdong-fe/
+|-- apps/web/                 # Next.js app package; source root is app/
+|   |-- app/                  # App Router routes, providers, app-only API/hooks/state
+|   |-- public/               # Fonts and static assets
+|   |-- next.config.js        # Sentry-wrapped Next config and image allowlist
+|   `-- package.json          # App scripts: dev/build/lint/check-types
+|-- packages/shared/          # @dds/shared UI library and small lib helpers
+|-- packages/eslint-config/   # Workspace ESLint config package
+|-- packages/tailwind-config/ # Workspace Tailwind preset package
+|-- packages/typescript-config/
+|-- packages/_templates/      # Hygen templates for package generation
+|-- turbo.json                # Task graph and build outputs
+`-- pnpm-workspace.yaml       # Workspace membership and catalog versions
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| App shell, metadata, analytics | `apps/web/app/layout.tsx` | Host prefix decides admin layout behavior. |
+| Client provider stack | `apps/web/app/providers.tsx` | Sentry, cookies, React Query, toast, upload progress, ChannelTalk. |
+| App routes | `apps/web/app/**/page.tsx` | Default exports; server pages are default unless marked `'use client'`. |
+| API calls and data types | `apps/web/app/_api` | `fetcher.ts` is the central ky client. |
+| Shared UI primitives | `packages/shared/ui` | Export through `packages/shared/index.ts`. |
+| Shared helper utilities | `packages/shared/lib` | `cn`, colors, and package-level helpers. |
+| Workspace scripts | `package.json`, `turbo.json` | Root commands fan out through Turbo. |
+| CI behavior | `.github/workflows/ci.yml` | PR checks run workspace quality gates. |
+
+## CODE MAP
+
+| Symbol | Type | Location | Refs | Role |
+| --- | --- | --- | --- | --- |
+| `RootLayout` | async Server Component | `apps/web/app/layout.tsx` | App Router entry | Loads font, metadata, providers, layout, analytics. |
+| `Providers` | Client Component | `apps/web/app/providers.tsx` | Root layout | Composes runtime client providers. |
+| `ClientQueryProvider` | Client Component | `apps/web/app/_api/ClientQueryProvider.tsx` | Provider stack | Owns React Query client setup. |
+| `instance` | ky client | `apps/web/app/_api/fetcher.ts` | Queries/mutations | Adds auth header, timeout, credentials, error hooks. |
+| `fetcher` | HTTP facade | `apps/web/app/_api/fetcher.ts` | API modules | Typed `get/post/put/delete/patch` wrappers. |
+| `parseResponse` | async helper | `apps/web/app/_api/fetcher.ts` | Fetcher methods | Converts JSON/blob responses and reports parse errors. |
+| `ApiError` | Error class | `apps/web/app/_api/fetcher.ts` | Error hook | Normalized API error shape. |
+| `OverviewPage` | async Server Component | `apps/web/app/(main)/page.tsx` | Public home route | Static public landing route. |
+| `Header`, `Button`, `Flex`, `Icon` | UI exports | `packages/shared/index.ts` | App imports as `@dds/shared` | Shared design system surface. |
+| `cn` | utility export | `packages/shared/lib/core.ts` | App and UI components | `clsx`/`tailwind-merge` class combiner. |
+
+TypeScript LSP was unavailable in this harness, so refs above are role-based from route entry points, exports, and call-site searches rather than live LSP counts.
+
+## CONVENTIONS
+
+- Use pnpm. Root scripts are Turbo wrappers: `pnpm dev`, `pnpm build`, `pnpm lint`, `pnpm check-types`.
+- The actual app source is `apps/web/app`; do not create a top-level `src/` tree for app code.
+- App path aliases are defined in `apps/web/tsconfig.json`: `@/*` maps to `apps/web/app/*`, with explicit aliases for `_api`, `_components`, `_utils`, `_store`, `_hooks`, `_constants`, `_types`, and `_lib`.
+- Route `page.tsx` files default-export the page component. Route-local client components in `_components`, `_pages`, `_containers`, and hooks use named exports unless an existing local pattern differs.
+- Prefer `@dds/shared` primitives before introducing app-local UI primitives.
+- Components use `function ComponentName(...)`; ordinary utilities and hooks commonly use arrow functions.
+- Use `type`, not `interface`, for new TypeScript shapes.
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+- Do not edit `apps/web/.next`, `packages/shared/dist`, `.turbo`, `node_modules`, `coverage`, `out`, or `build`; these are generated/vendor outputs.
+- Do not treat `CLAUDE.md` as a fresher source than this file; it currently mirrors older root guidance.
+- Do not duplicate API error handling in feature modules; keep token expiration, Sentry capture, and response parsing centered in `_api/fetcher.ts`.
+- Do not import directly from `packages/shared/dist`; source changes belong in `packages/shared/ui` or `packages/shared/lib`.
+- Current explicit TODO: `apps/web/app/admin/member/_components/ExcelDropdown.tsx` notes replacing the Excel image.
+
+## UNIQUE STYLES
+
+- Route folders use leading-underscore local modules: `_components`, `_containers`, `_hooks`, `_pages`, `_utils`, `_constants`, `_schemas`, `_contexts`, `_types`.
+- Admin and public routes live in the same App Router tree; admin host behavior is resolved in `RootLayout` and `LayoutClient`.
+- Many user-facing strings are Korean; preserve surrounding tone and terminology when editing copy.
+- Shared UI components usually have `Component.tsx`, `Component.stories.tsx`, and `index.ts` in the component folder.
+
+## COMMANDS
+
+```bash
+pnpm dev
+pnpm build
+pnpm lint
+pnpm lint:fix
+pnpm check-types
+pnpm --filter @ddingdong/web dev
+pnpm --filter @dds/shared storybook
+```
+
+## NOTES
+
+- Node engine is `>=22`; package manager is `pnpm@9.15.4`.
+- Turbo build outputs include `.next/**` and `dist/**`; cache artifacts should not drive documentation placement.
+- No test files were found under `test`, `apps/web/test`, or `apps/web/__tests__` during init-deep discovery.

--- a/apps/web/app/AGENTS.md
+++ b/apps/web/app/AGENTS.md
@@ -1,0 +1,50 @@
+# APP ROUTER KNOWLEDGE
+
+## OVERVIEW
+
+`apps/web/app` is the real Next.js source root. It contains public routes, admin routes, app-only shared modules, and the runtime provider shell.
+
+## STRUCTURE
+
+```text
+app/
+|-- layout.tsx          # Root server layout, font, metadata, host detection
+|-- providers.tsx       # Client provider stack
+|-- (main)/             # Public home route group
+|-- admin/              # Admin product routes
+|-- apply/ club/ ...    # Public feature routes
+|-- _api/               # ky fetcher, React Query modules, API types
+|-- _components/        # App-wide components and layout
+|-- _hooks/ _utils/     # App-wide hooks and helpers
+|-- _store/             # Zustand stores
+`-- _styles/            # Global CSS
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Global shell | `layout.tsx` | Server component; reads host and wraps `LayoutClient`. |
+| Client runtime providers | `providers.tsx` | Must stay `'use client'`; wraps children in Sentry/Cookies/React Query. |
+| Public home | `(main)/page.tsx` | Static route with `revalidate` and `dynamic` exports. |
+| Public feeds | `feeds` | List/detail route with route-local components, hooks, pages. |
+| Public notices | `notice` | List/detail route. |
+| Public documents/FAQ | `documents`, `faq` | Client pages under `_pages`. |
+| Admin product | `admin` | Has its own scoped instructions. |
+| API integration | `_api` | Has its own scoped instructions. |
+
+## CONVENTIONS
+
+- Page files default-export the route component. Server pages use `export default async function`; client pages start with `'use client'` and use `export default function`.
+- Components inside `_components`, `_pages`, `_containers`, and hooks use named exports by default.
+- Keep route-specific code inside the route folder. Promote to app-wide `_components`, `_hooks`, `_utils`, or `_constants` only when reused across multiple routes.
+- Use aliases from `apps/web/tsconfig.json`; `@/*` means this `app/` directory, not the repo root.
+- Use `@dds/shared` for UI primitives and `cn()` for conditional Tailwind classes.
+- Preserve Korean copy and domain terms already used in the surrounding route.
+
+## ANTI-PATTERNS
+
+- Do not add `src/app`; this package uses `apps/web/app` directly.
+- Do not put feature-specific state or helpers in app-wide underscore folders unless at least two routes use them.
+- Do not make client components by accident: add `'use client'` only when hooks, browser APIs, events, or client providers require it.
+- Do not bypass `providers.tsx` for new app-wide providers; keep provider ordering explicit there.

--- a/apps/web/app/_api/AGENTS.md
+++ b/apps/web/app/_api/AGENTS.md
@@ -1,0 +1,46 @@
+# API LAYER KNOWLEDGE
+
+## OVERVIEW
+
+`_api` owns HTTP transport, React Query setup, API request modules, response types, and file services for the Next app.
+
+## STRUCTURE
+
+```text
+_api/
+|-- fetcher.ts              # ky instance, auth cookies, error normalization
+|-- ClientQueryProvider.tsx # React Query provider/client
+|-- useCookie.ts            # Cookie helpers
+|-- revalidate.ts           # Revalidation helper
+|-- queries/                # Domain query functions
+|-- mutations/              # Domain mutation functions
+|-- services/               # Non-CRUD service helpers
+`-- types/                  # API DTO/request/response types by domain
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Add endpoint call | `queries/{domain}.ts` or `mutations/{domain}.ts` | Match the existing domain split. |
+| Add DTO/type | `types/{domain}.ts` | Keep request/response names close to Swagger names. |
+| Change auth/error behavior | `fetcher.ts` | Central place for cookies, 401 handling, Sentry capture. |
+| Change QueryClient defaults | `ClientQueryProvider.tsx` | Client-only provider setup. |
+| File upload/download | `services/file.ts`, domain modules | Use existing blob/file response paths. |
+
+## CONVENTIONS
+
+- API modules should call the exported `fetcher`, not raw `ky`.
+- `fetcher.ts` sets `credentials: 'include'`, `retry: 0`, `timeout: 30_000`, and the bearer token from the `token` cookie.
+- 401 with message `유효하지 않은 토큰입니다.` logs the user out through `expirationToken`; do not duplicate this in feature code.
+- Convert responses through `parseResponse<T>` so JSON/blob handling and Sentry reporting stay central.
+- Keep domain file names aligned across `queries`, `mutations`, and `types` when adding a new backend domain.
+- Keep React Query hooks or callers outside `_api` unless the existing file is already a hook/provider.
+
+## ANTI-PATTERNS
+
+- Do not swallow `ApiError`; callers should handle user-facing recovery where appropriate.
+- Do not read `process.env.NEXT_PUBLIC_BASE_URL` outside `fetcher.ts` for normal app API calls.
+- Do not create ad hoc DTOs inside route components when a shared API type belongs in `types/`.
+- Do not mock React Query internals in tests; mock API responses only if tests are added.
+- Known footguns found during init: `queries/notice.ts` nests `noticeQueryKeys.all(1)` inside `detail()`, `queries/score.ts` uses PascalCase key/option exports, `types/file.ts` and `types/common.ts` both define `PresignedUrlResponse`, and `types/apply.ts` is a large mixed DTO file.

--- a/apps/web/app/admin/AGENTS.md
+++ b/apps/web/app/admin/AGENTS.md
@@ -1,0 +1,52 @@
+# ADMIN ROUTES KNOWLEDGE
+
+## OVERVIEW
+
+`apps/web/app/admin` contains the admin product: dashboards, content management, club/member tools, applications, emails, reports, ranking, and fix workflows.
+
+## STRUCTURE
+
+```text
+admin/
+|-- (home)/          # Admin landing/dashboard route group
+|-- apply/           # Forms, applicants, emails, statistics
+|-- banner/          # Banner management
+|-- club/            # Club management
+|-- documents/       # Document management
+|-- faq/ feed/ notice/
+|-- fix/             # Fix/report workflow
+|-- login/           # Admin auth entry
+|-- member/          # Member management and Excel upload
+|-- my-club/ ranking/ report/
+`-- */_components, */_hooks, */_pages, */_utils, */_schemas
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Admin route entry | `*/page.tsx` | Default-export page components. |
+| Complex application flow | `apply` | New form builder, applicant detail, email, statistics. |
+| Member operations | `member` | Cards, add/delete/upload modals, Excel dropdown. |
+| Report authoring/detail | `report/[term]` | New/detail/fix flows. |
+| Fix workflow | `fix` | List, detail, new post, comments, resolution. |
+| Shared admin API calls | `../_api/queries/*`, `../_api/mutations/*` | Admin routes still use app-wide API layer. |
+
+## CONVENTIONS
+
+- Keep admin feature code inside its domain route folder. Use the local `_components`, `_hooks`, `_pages`, `_utils`, `_constants`, or `_schemas` first.
+- Client-heavy admin pages usually delegate to a route-local `_pages/*ClientPage.tsx` component from `page.tsx`.
+- Query-driven server pages often create a `QueryClient`, prefetch data, and pass a hydrated client page through `HydrationBoundary`; follow examples in `apply/page.tsx` and `report/page.tsx`.
+- Dynamic server pages commonly type `params` as a `Promise` and `await params`; report routes also use `generateMetadata`.
+- Role-dependent pages should read `cookies()` server-side and pass role into client components rather than duplicating role lookup in browser code.
+- Form-heavy flows use local reducers, schemas, and utilities inside the feature folder; follow the existing `apply/new` split before adding new shared abstractions.
+- Use `@dds/shared` primitives and existing admin card/modal/dropdown patterns before inventing new local UI.
+- Preserve the existing Korean admin terminology in labels, toast messages, and status strings.
+
+## ANTI-PATTERNS
+
+- Do not move admin-only helpers to app-wide `_utils` just because another admin file imports them; keep the route boundary tight until reused outside admin.
+- Do not bypass `_api/fetcher.ts` for admin requests.
+- Do not put browser-only logic in server `page.tsx`; isolate it in client components/hooks.
+- Folder naming has historical inconsistencies (`fix/_component`, `fix/_container`, `club/_constant`, `notice/[id]/edit/_hook`); preserve local imports unless intentionally normalizing a whole route family.
+- Current explicit TODO: `member/_components/ExcelDropdown.tsx` has `TODO: 엑셀 이미지로 변경`.

--- a/apps/web/app/admin/apply/[id]/edit/_hooks/useFormEdit.ts
+++ b/apps/web/app/admin/apply/[id]/edit/_hooks/useFormEdit.ts
@@ -6,13 +6,10 @@ import { toast } from 'react-hot-toast';
 import { ApiError } from '@/_api/fetcher';
 import { useUpdateForm } from '@/_api/mutations/apply';
 import { applyQueryOptions } from '@/_api/queries/apply';
+import { formatDate, parseLocalDate } from '@/admin/apply/_utils/dateFormat';
 import { useFormFieldReducer } from '@/admin/apply/new/_hooks/reducer/useFormFieldReducer';
 import { FormBasicInfo } from '@/admin/apply/new/_hooks/useFormBasicInfo';
-import {
-  formatDate,
-  formatFormData,
-  parseLocalDate,
-} from '@/admin/apply/new/_utils/format';
+import { formatFormData } from '@/admin/apply/new/_utils/format';
 import {
   validateBasicInfo,
   validateQuestions,
@@ -96,23 +93,48 @@ export function useFormEdit(formId: number) {
   };
 
   const handleSave = () => {
-    if (canEditContent && !validateBasicInfo(basicInfo)) {
+    if (!formData.startDate || !formData.endDate) {
+      toast.error('지원서를 수정할 수 있는 기간이 아닙니다.');
+      return;
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const startDate = parseLocalDate(formData.startDate);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = parseLocalDate(formData.endDate);
+    endDate.setHours(0, 0, 0, 0);
+
+    const currentIsBeforeRecruiting = today.getTime() < startDate.getTime();
+    const currentIsRecruiting =
+      startDate.getTime() <= today.getTime() &&
+      today.getTime() <= endDate.getTime();
+
+    if (!currentIsBeforeRecruiting && !currentIsRecruiting) {
+      toast.error('지원서를 수정할 수 있는 기간이 아닙니다.');
+      return;
+    }
+
+    if (currentIsBeforeRecruiting && !validateBasicInfo(basicInfo)) {
       return;
     }
 
     if (
-      !canEditContent &&
+      !currentIsBeforeRecruiting &&
       (!basicInfo.recruitPeriod.startDate || !basicInfo.recruitPeriod.endDate)
     ) {
       toast.error('모집 기간을 입력해주세요.');
       return;
     }
 
-    if (canEditContent && !validateQuestions(formFieldState.formField)) {
+    if (
+      currentIsBeforeRecruiting &&
+      !validateQuestions(formFieldState.formField)
+    ) {
       return;
     }
 
-    const updatedFormData = canEditContent
+    const updatedFormData = currentIsBeforeRecruiting
       ? formatFormData(
           basicInfo,
           formFieldState.sections,

--- a/apps/web/app/admin/apply/[id]/edit/_hooks/useFormEdit.ts
+++ b/apps/web/app/admin/apply/[id]/edit/_hooks/useFormEdit.ts
@@ -8,6 +8,7 @@ import { useUpdateForm } from '@/_api/mutations/apply';
 import { applyQueryOptions } from '@/_api/queries/apply';
 import { useFormFieldReducer } from '@/admin/apply/new/_hooks/reducer/useFormFieldReducer';
 import { FormBasicInfo } from '@/admin/apply/new/_hooks/useFormBasicInfo';
+import { formatDate } from '@/admin/apply/new/_utils/format';
 
 import {
   transformFormDataToBasicInfo,
@@ -72,24 +73,14 @@ export function useFormEdit(formId: number) {
       toast.error('모집 기간을 입력해주세요.');
       return;
     }
-    const formatLocalDate = (date: Date | string): string => {
-      if (typeof date === 'string') {
-        return date;
-      }
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-
     updateForm(
       {
         formId,
         formData: {
           title: basicInfo.title,
           description: basicInfo.description,
-          startDate: formatLocalDate(basicInfo.recruitPeriod.startDate),
-          endDate: formatLocalDate(basicInfo.recruitPeriod.endDate),
+          startDate: formatDate(basicInfo.recruitPeriod.startDate),
+          endDate: formatDate(basicInfo.recruitPeriod.endDate),
           hasInterview: basicInfo.hasInterview,
           sections: formData.sections || [],
           formFields: formData.formFields || [],

--- a/apps/web/app/admin/apply/[id]/edit/_hooks/useFormEdit.ts
+++ b/apps/web/app/admin/apply/[id]/edit/_hooks/useFormEdit.ts
@@ -8,7 +8,15 @@ import { useUpdateForm } from '@/_api/mutations/apply';
 import { applyQueryOptions } from '@/_api/queries/apply';
 import { useFormFieldReducer } from '@/admin/apply/new/_hooks/reducer/useFormFieldReducer';
 import { FormBasicInfo } from '@/admin/apply/new/_hooks/useFormBasicInfo';
-import { formatDate } from '@/admin/apply/new/_utils/format';
+import {
+  formatDate,
+  formatFormData,
+  parseLocalDate,
+} from '@/admin/apply/new/_utils/format';
+import {
+  validateBasicInfo,
+  validateQuestions,
+} from '@/admin/apply/new/_utils/validation';
 
 import {
   transformFormDataToBasicInfo,
@@ -19,20 +27,29 @@ export function useFormEdit(formId: number) {
   const { data: formData } = useSuspenseQuery(applyQueryOptions.form(formId));
   const { mutate: updateForm, isPending } = useUpdateForm();
 
-  // 현재 모집 중인지 확인
-  const isRecruiting = useMemo(() => {
-    if (!formData.startDate || !formData.endDate) return false;
+  const { canEditForm, canEditContent } = useMemo(() => {
+    if (!formData.startDate || !formData.endDate) {
+      return {
+        canEditForm: false,
+        canEditContent: false,
+      };
+    }
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const startDate = new Date(formData.startDate);
+    const startDate = parseLocalDate(formData.startDate);
     startDate.setHours(0, 0, 0, 0);
-    const endDate = new Date(formData.endDate);
+    const endDate = parseLocalDate(formData.endDate);
     endDate.setHours(0, 0, 0, 0);
 
-    return (
+    const isBeforeRecruiting = today.getTime() < startDate.getTime();
+    const isRecruiting =
       startDate.getTime() <= today.getTime() &&
-      today.getTime() <= endDate.getTime()
-    );
+      today.getTime() <= endDate.getTime();
+
+    return {
+      canEditForm: isBeforeRecruiting || isRecruiting,
+      canEditContent: isBeforeRecruiting,
+    };
   }, [formData.startDate, formData.endDate]);
 
   const [isEditing, setIsEditing] = useState(false);
@@ -54,37 +71,67 @@ export function useFormEdit(formId: number) {
   const contextValue = useMemo(
     () => ({
       ...formFieldState,
-      formField: sectionFormField,
     }),
-    [formFieldState, sectionFormField],
+    [formFieldState],
   );
 
   const handleBasicInfoChange = (updates: Partial<FormBasicInfo>) => {
     if (isEditing) {
-      setBasicInfo((prev) => ({ ...prev, ...updates }));
+      setBasicInfo((prev) => ({
+        title:
+          canEditContent && updates.title !== undefined
+            ? updates.title
+            : prev.title,
+        description:
+          canEditContent && updates.description !== undefined
+            ? updates.description
+            : prev.description,
+        hasInterview:
+          canEditContent && updates.hasInterview !== undefined
+            ? updates.hasInterview
+            : prev.hasInterview,
+        recruitPeriod: updates.recruitPeriod ?? prev.recruitPeriod,
+      }));
     }
   };
 
   const handleSave = () => {
+    if (canEditContent && !validateBasicInfo(basicInfo)) {
+      return;
+    }
+
     if (
-      !basicInfo.recruitPeriod.startDate ||
-      !basicInfo.recruitPeriod.endDate
+      !canEditContent &&
+      (!basicInfo.recruitPeriod.startDate || !basicInfo.recruitPeriod.endDate)
     ) {
       toast.error('모집 기간을 입력해주세요.');
       return;
     }
+
+    if (canEditContent && !validateQuestions(formFieldState.formField)) {
+      return;
+    }
+
+    const updatedFormData = canEditContent
+      ? formatFormData(
+          basicInfo,
+          formFieldState.sections,
+          formFieldState.formField,
+        )
+      : {
+          title: formData.title,
+          description: formData.description ?? null,
+          startDate: formatDate(basicInfo.recruitPeriod.startDate),
+          endDate: formatDate(basicInfo.recruitPeriod.endDate),
+          hasInterview: formData.hasInterview,
+          sections: formData.sections || [],
+          formFields: formData.formFields || [],
+        };
+
     updateForm(
       {
         formId,
-        formData: {
-          title: basicInfo.title,
-          description: basicInfo.description,
-          startDate: formatDate(basicInfo.recruitPeriod.startDate),
-          endDate: formatDate(basicInfo.recruitPeriod.endDate),
-          hasInterview: basicInfo.hasInterview,
-          sections: formData.sections || [],
-          formFields: formData.formFields || [],
-        },
+        formData: updatedFormData,
       },
       {
         onSuccess: async () => {
@@ -117,6 +164,7 @@ export function useFormEdit(formId: number) {
     handleCancel,
     isPending,
     contextValue,
-    isRecruiting,
+    canEditForm,
+    canEditContent,
   };
 }

--- a/apps/web/app/admin/apply/[id]/edit/_pages/FormEditPage.tsx
+++ b/apps/web/app/admin/apply/[id]/edit/_pages/FormEditPage.tsx
@@ -22,7 +22,8 @@ export function FormEditPage({ formId }: FormEditPageProps) {
     handleCancel,
     isPending,
     contextValue,
-    isRecruiting,
+    canEditForm,
+    canEditContent,
   } = useFormEdit(formId);
 
   return (
@@ -34,7 +35,7 @@ export function FormEditPage({ formId }: FormEditPageProps) {
         className="pt-7 md:pt-10"
       >
         <Title1 weight="bold">지원서 수정</Title1>
-        {isRecruiting &&
+        {canEditForm &&
           (isEditing ? (
             <Flex gap={2}>
               <Button
@@ -66,9 +67,10 @@ export function FormEditPage({ formId }: FormEditPageProps) {
       <FormHeaderSection
         basicInfo={basicInfo}
         onBasicInfoChange={handleBasicInfoChange}
-        readOnly={!isEditing}
+        readOnly={!isEditing || !canEditContent}
+        recruitPeriodReadOnly={!isEditing}
       />
-      <SectionContent readOnly={!isEditing || isRecruiting} />
+      <SectionContent readOnly={!isEditing || !canEditContent} />
     </FormFieldContext.Provider>
   );
 }

--- a/apps/web/app/admin/apply/[id]/edit/_utils/transformFormData.ts
+++ b/apps/web/app/admin/apply/[id]/edit/_utils/transformFormData.ts
@@ -1,7 +1,6 @@
-import { DateRangeType } from 'react-tailwindcss-datepicker/dist/types';
-
 import { FormAPIResponse, SectionFormField } from '@/_api/types/apply';
 import { FormBasicInfo } from '@/admin/apply/new/_hooks/useFormBasicInfo';
+import { parseLocalDate } from '@/admin/apply/new/_utils/format';
 
 export function transformFormDataToBasicInfo(
   formData: FormAPIResponse,
@@ -11,9 +10,9 @@ export function transformFormDataToBasicInfo(
     description: formData.description || '',
     hasInterview: formData.hasInterview,
     recruitPeriod: {
-      startDate: new Date(formData.startDate),
-      endDate: new Date(formData.endDate),
-    } as DateRangeType,
+      startDate: parseLocalDate(formData.startDate),
+      endDate: parseLocalDate(formData.endDate),
+    },
   };
 }
 
@@ -25,10 +24,14 @@ export function transformFormDataToSectionFormField(
   const formFields = formData.formFields;
   if (formFields && Array.isArray(formFields)) {
     formFields.forEach((field) => {
-      if (!sectionMap.has(field.section)) {
-        sectionMap.set(field.section, []);
+      const sectionFields = sectionMap.get(field.section);
+
+      if (sectionFields) {
+        sectionFields.push(field);
+        return;
       }
-      sectionMap.get(field.section)!.push(field);
+
+      sectionMap.set(field.section, [field]);
     });
   }
 

--- a/apps/web/app/admin/apply/[id]/edit/_utils/transformFormData.ts
+++ b/apps/web/app/admin/apply/[id]/edit/_utils/transformFormData.ts
@@ -1,6 +1,6 @@
 import { FormAPIResponse, SectionFormField } from '@/_api/types/apply';
+import { parseLocalDate } from '@/admin/apply/_utils/dateFormat';
 import { FormBasicInfo } from '@/admin/apply/new/_hooks/useFormBasicInfo';
-import { parseLocalDate } from '@/admin/apply/new/_utils/format';
 
 export function transformFormDataToBasicInfo(
   formData: FormAPIResponse,

--- a/apps/web/app/admin/apply/_utils/dateFormat.ts
+++ b/apps/web/app/admin/apply/_utils/dateFormat.ts
@@ -1,0 +1,20 @@
+export function parseLocalDate(date: string): Date {
+  const [yearText, monthText, dayText] = date.split('-');
+
+  if (!yearText || !monthText || !dayText) {
+    return new Date(date);
+  }
+
+  return new Date(Number(yearText), Number(monthText) - 1, Number(dayText));
+}
+
+export function formatDate(date: Date | string | null): string {
+  if (!date) return '';
+
+  const localDate = date instanceof Date ? date : parseLocalDate(date);
+  const year = localDate.getFullYear();
+  const month = String(localDate.getMonth() + 1).padStart(2, '0');
+  const day = String(localDate.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}

--- a/apps/web/app/admin/apply/new/_components/FormHeaderSection.tsx
+++ b/apps/web/app/admin/apply/new/_components/FormHeaderSection.tsx
@@ -9,12 +9,14 @@ type FormHeaderSectionProps = {
   basicInfo: FormBasicInfo;
   onBasicInfoChange: (updates: Partial<FormBasicInfo>) => void;
   readOnly?: boolean;
+  recruitPeriodReadOnly?: boolean;
 };
 
 export function FormHeaderSection({
   basicInfo,
   onBasicInfoChange,
   readOnly = false,
+  recruitPeriodReadOnly = readOnly,
 }: FormHeaderSectionProps) {
   const { title, description, recruitPeriod, hasInterview } = basicInfo;
   return (
@@ -66,7 +68,7 @@ export function FormHeaderSection({
               minDate={new Date(new Date().getFullYear(), 0, 1)}
               maxDate={new Date(new Date().getFullYear(), 11, 31)}
               inputClassName="w-full rounded-xl bg-white px-4 py-3.5 border border-gray-200 focus:ring-4 focus:ring-blue-200 focus:border-blue-500 focus:outline-none"
-              disabled={readOnly}
+              disabled={recruitPeriodReadOnly}
             />
           </div>
         </Flex>

--- a/apps/web/app/admin/apply/new/_utils/format.ts
+++ b/apps/web/app/admin/apply/new/_utils/format.ts
@@ -7,10 +7,26 @@ import {
 
 import { FormBasicInfo } from '../_hooks/useFormBasicInfo';
 
+export function parseLocalDate(date: string): Date {
+  const [yearText, monthText, dayText] = date.split('-');
+
+  if (!yearText || !monthText || !dayText) {
+    return new Date(date);
+  }
+  console.log(date);
+
+  return new Date(Number(yearText), Number(monthText) - 1, Number(dayText));
+}
+
 export function formatDate(date: Date | string | null): string {
   if (!date) return '';
-  if (date instanceof Date) return date.toISOString().split('T')[0];
-  return new Date(date).toISOString().split('T')[0];
+
+  const localDate = date instanceof Date ? date : parseLocalDate(date);
+  const year = localDate.getFullYear();
+  const month = String(localDate.getMonth() + 1).padStart(2, '0');
+  const day = String(localDate.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 }
 
 export function formatFormData(

--- a/apps/web/app/admin/apply/new/_utils/format.ts
+++ b/apps/web/app/admin/apply/new/_utils/format.ts
@@ -4,30 +4,9 @@ import {
   QuestionType,
   SectionFormField,
 } from '@/_api/types/apply';
+import { formatDate } from '@/admin/apply/_utils/dateFormat';
 
 import { FormBasicInfo } from '../_hooks/useFormBasicInfo';
-
-export function parseLocalDate(date: string): Date {
-  const [yearText, monthText, dayText] = date.split('-');
-
-  if (!yearText || !monthText || !dayText) {
-    return new Date(date);
-  }
-  console.log(date);
-
-  return new Date(Number(yearText), Number(monthText) - 1, Number(dayText));
-}
-
-export function formatDate(date: Date | string | null): string {
-  if (!date) return '';
-
-  const localDate = date instanceof Date ? date : parseLocalDate(date);
-  const year = localDate.getFullYear();
-  const month = String(localDate.getMonth() + 1).padStart(2, '0');
-  const day = String(localDate.getDate()).padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
-}
 
 export function formatFormData(
   basicInfo: FormBasicInfo,

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,0 +1,46 @@
+# SHARED PACKAGE KNOWLEDGE
+
+## OVERVIEW
+
+`packages/shared` builds `@dds/shared`, the local UI/component package consumed by the web app.
+
+## STRUCTURE
+
+```text
+shared/
+|-- index.ts        # Public barrel for @dds/shared
+|-- lib/            # cn, colors, small package utilities
+|-- ui/             # Component folders with component, story, index files
+|-- vite.config.ts  # Library build
+|-- tsconfig.json   # Package TS config
+`-- dist/           # Generated build output; do not edit
+```
+
+## WHERE TO LOOK
+
+| Task                        | Location                                      | Notes                                                      |
+| --------------------------- | --------------------------------------------- | ---------------------------------------------------------- |
+| Add exported component      | `ui/{Component}` and `index.ts`               | Add source files, local index, then package barrel export. |
+| Change shared styles/tokens | `lib/colors.ts`, `ui/Typography`, `ui/Colors` | Check stories/MDX examples too.                            |
+| Component behavior          | `ui/{Component}/{Component}.tsx`              | Keep props typed near component.                           |
+| Storybook coverage          | `ui/{Component}/{Component}.stories.tsx`      | Existing components usually include a story.               |
+| Package build config        | `package.json`, `vite.config.ts`              | Build emits `dist`.                                        |
+| Generate component scaffold | `pnpm --filter @dds/shared gen`               | Uses `packages/_templates/components/new`.                 |
+
+## CONVENTIONS
+
+- Public imports should go through `@dds/shared`; app code should not reach into package internals unless no barrel export exists yet.
+- Component folders commonly use `Component.tsx`, `Component.stories.tsx`, and `index.ts` or `index.tsx`.
+- Storybook discovers `../ui/**/*.mdx` and `../ui/**/*.stories.@(js|jsx|mjs|ts|tsx)`; keep MDX docs near visual token/icon systems.
+- Hygen templates create the component, story, and local index from a PascalCase name.
+- Add or update `packages/shared/index.ts` when a new primitive should be public.
+- Use `cn` from `lib/core.ts` for class merging inside shared components.
+- Keep shared components domain-neutral; app-specific wording or behavior belongs in `apps/web/app`.
+- Stories are part of the component contract; update them when props, variants, or visible states change.
+
+## ANTI-PATTERNS
+
+- Do not edit `dist`; run the package build if generated output is needed.
+- Do not import app aliases like `@/_components` from this package.
+- Do not introduce app-domain strings or API calls into shared UI primitives.
+- Do not create a shared component for one route-specific need until reuse is real.


### PR DESCRIPTION
<!-- 제목은 반드시 아래 태그 중 하나로 시작해주세요 -->

<!-- [FEAT]     새로운 기능 추가 -->
<!-- [FIX]      버그 수정 -->
<!-- [HOTFIX]   긴급 버그 수정 -->
<!-- [DOCS]     문서 추가/수정 -->
<!-- [STYLE]    코드 스타일 변경 (포맷, 세미콜론 등) -->
<!-- [REFACTOR] 코드 리팩토링 -->
<!-- [TEST]     테스트 코드 추가/수정 -->
<!-- [CHORE]    빌드, 설정, 패키지 관리 등 기타 작업 -->

<!-- 예시 -->
<!-- [FEAT] 로그인 API 추가 -->

## 🔥 연관 이슈

- close #407 

## 🚀 작업 내용

### 날짜 밀림 버그
기존 문제는 toISOString()이 항상 UTC 기준 문자열을 만들기 때문에, 한국 시간 2026-07-01 00:00 같은 로컬 날짜가 UTC로는 2026-06-30T15:00:00.000Z가 되면서 날짜가 하루 앞당겨질 수 있었습니다.
이번 수정은: API에서 받은 '2026-07-01' 문자열을 new Date('2026-07-01')로 바로 만들지 않고 year, month, day를 직접 쪼개서
new Date(2026, 6, 1)처럼 로컬 날짜 객체로 만들고 다시 API에 보낼 때도 toISOString()을 쓰지 않고 getFullYear(), getMonth(), getDate()로 YYYY-MM-DD를 직접 조립해서 결과를 리턴했습니다.

### 지원서 수정 안되는 버그
useFormEdit.ts에는 canEditForm, canEditContent 계산이 들어가 있었습니다.
그런데 FormEditPage.tsx는 여전히 기존 값인 isRecruiting을 쓰고 있었습니다.
FormHeaderSection.tsx도 여전히 readOnly 하나로 제목/설명/모집기간을 같이 잠그고 있었습니다.

## 🤔 고민했던 내용

지원서 수정이 안되는 버그를 수정하며 값을 명시 시키는게 좋다고 생각하여  handelBasicInfoChange 함수가 길어졌는데 이런 부분이 괜찮을지 궁금합니다.

## 💬 리뷰 중점사항

제가 이해하고 있는 것으로는 모집일 전, 그리고 모집일 이후 지원서 날짜 변경이 가능한 것으로 알고있습니다. 
혹여나 제가 이해하고 있는게 다를 수 있어 피드백 주시면 수정하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 지원서/폼의 날짜 입력과 표시가 로컬 기준으로 처리되어, 날짜가 하루 어긋나 보이던 문제가 개선되었습니다.
  * 편집 가능 여부가 더 세분화되어, 모집 기간과 기본 정보/질문 수정 상태가 더 정확하게 반영됩니다.

* **Documentation**
  * 프로젝트 구조, 작업 규칙, 공통 개발 가이드가 추가되어 문서화가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->